### PR TITLE
feat(Anchor): provide Button-looking anchor element

### DIFF
--- a/src/components/Button/Anchor.stories.tsx
+++ b/src/components/Button/Anchor.stories.tsx
@@ -1,0 +1,26 @@
+import { Story, Meta } from "@storybook/react";
+import { Anchor, AnchorPropType } from ".";
+
+export default {
+  title: "UI Elements/Anchor",
+  component: Anchor,
+} as Meta;
+
+const AnchorTemplate: Story<AnchorPropType> = ({
+  children,
+  variant,
+  href = "/",
+}) => (
+  <Anchor variant={variant} href={href}>
+    {typeof children === "string" ? children : "Default anchor text"}
+  </Anchor>
+);
+
+export const DefaultAnchor = AnchorTemplate.bind({});
+DefaultAnchor.args = { children: "Anchor (looking like a button)" };
+
+export const PrimaryAnchor = AnchorTemplate.bind({});
+PrimaryAnchor.args = {
+  variant: "primary",
+  children: "Anchor (looking like a primary button)",
+};

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { Button, Submit } from ".";
+import { Button, Submit, Anchor } from ".";
 
 describe("Button component", () => {
   it("should have a button type", () => {
@@ -96,5 +96,38 @@ describe("Submit component", () => {
     render(<Submit disabled>Submit</Submit>);
     const submit = screen.getByText("Submit");
     expect(submit.getAttribute("class")?.includes("cursor-default")).toBe(true);
+  });
+});
+
+describe("Anchor component", () => {
+  it("should render a link", () => {
+    render(<Anchor href='/'>Some link</Anchor>);
+    const anchor = screen.getByRole("link", { name: /Some link/g });
+    expect(anchor).toBeInTheDocument();
+  });
+  it("should have basic styles", () => {
+    render(<Anchor href='/'>Some link</Anchor>);
+    const anchor = screen.getByRole("link", { name: /Some link/g });
+    expect(anchor.getAttribute("class")?.includes("transition")).toBe(true);
+  });
+  it("should have default styles when default", () => {
+    render(<Anchor href='/'>Some link</Anchor>);
+    const anchor = screen.getByRole("link", { name: /Some link/g });
+    expect(anchor.getAttribute("class")?.includes("cursor-pointer")).toBe(true);
+  });
+  it("should have primary styles when primary", () => {
+    render(<Anchor href='/'>Some link</Anchor>);
+    const anchor = screen.getByRole("link", { name: /Some link/g });
+    expect(anchor.getAttribute("class")?.includes("bg-blue-500")).toBe(true);
+  });
+  it("should have open-in-new-tab attributes when provided", () => {
+    render(
+      <Anchor href='/' target='_blank' rel='noopener noreferrer'>
+        Some link
+      </Anchor>
+    );
+    const anchor = screen.getByRole("link", { name: /Some link/g });
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
   });
 });

--- a/src/components/Button/__snapshots__/Anchor.stories.storyshot
+++ b/src/components/Button/__snapshots__/Anchor.stories.storyshot
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots UI Elements/Anchor Default Anchor 1`] = `
+<a
+  className="px-4 py-2 font-sans text-lg transition cursor-pointer focus-offset bg-white border border-blue-500 text-blue-500 hover:bg-blue-500 hover:bg-opacity-10"
+  href="/"
+>
+  Anchor (looking like a button)
+</a>
+`;
+
+exports[`Storyshots UI Elements/Anchor Primary Anchor 1`] = `
+<a
+  className="px-4 py-2 font-sans text-lg transition cursor-pointer focus-offset bg-blue-500 text-white hover:opacity-60"
+  href="/"
+  variant="primary"
+>
+  Anchor (looking like a primary button)
+</a>
+`;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,6 +6,13 @@ interface ButtonPropType
   disabled?: boolean;
   variant?: "primary" | "secondary" | "dangerous";
 }
+
+export interface AnchorPropType
+  extends Omit<HTMLProps<HTMLAnchorElement>, "children"> {
+  children: ReactNode;
+  variant?: "primary" | "secondary";
+  href: string;
+}
 interface SubmitPropType extends Omit<HTMLProps<HTMLInputElement>, "children"> {
   children: string;
   disabled?: boolean;
@@ -82,5 +89,19 @@ export const Submit = forwardRef<HTMLInputElement, SubmitPropType>(
       className={getButtonStyles(submitProps)}
       value={children}
     />
+  )
+);
+
+// eslint-disable-next-line react/display-name
+export const Anchor = forwardRef<HTMLAnchorElement, AnchorPropType>(
+  ({ href, children, ...anchorProps }, ref) => (
+    <a
+      href={href}
+      {...anchorProps}
+      ref={ref}
+      className={getButtonStyles(anchorProps)}
+    >
+      {children}
+    </a>
   )
 );


### PR DESCRIPTION
This PR adds a semantic anchor (e.g. `<a href="/"></a>`) element that looks like a button as this is something that is needed in several parts of the UI.