### PR TITLE
feat(ProjectInfo): fire function for 'edit project'

### DIFF
--- a/src/components/ProjectInfo/ProjectInfo.stories.tsx
+++ b/src/components/ProjectInfo/ProjectInfo.stories.tsx
@@ -1,9 +1,11 @@
 import { Story, Meta } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 import { ProjectInfo, ProjectInfoPropType } from ".";
 
 export default {
   title: "Layout/ProjectInfo",
   component: ProjectInfo,
+  argTypes: { onEditProject: { action: "Clicked edit project" } },
 } as Meta;
 
 const ProjectInfoTemplate: Story<ProjectInfoPropType> = ({
@@ -16,7 +18,7 @@ DefaultProjectInfo.args = {
   title: "Temperatur Grunewaldstraße",
   category: "Temperatur",
   projectViewLink: "/123abc",
-  editLink: "/123abc/edit",
+  onEditProject: action("Clicked edit project"),
   children:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
 };

--- a/src/components/ProjectInfo/ProjectInfo.test.tsx
+++ b/src/components/ProjectInfo/ProjectInfo.test.tsx
@@ -1,18 +1,20 @@
 import { render, screen } from "@testing-library/react";
-import { ProjectInfo } from ".";
+import userEvent from "@testing-library/user-event";
+import { ProjectInfo, ProjectInfoPropType } from ".";
 
-const exampleArgs = {
+const editProjectFunction = jest.fn();
+
+const exampleArgs: ProjectInfoPropType = {
   title: "A title",
   category: "A category",
   projectViewLink: "/123abc",
-  editLink: "/123abc/edit",
+  onEditProject: editProjectFunction,
+  children: <p>Description</p>,
 };
-const exampleText =
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
 
 describe("ProjectInfo component", () => {
   it("should display a h2 title", () => {
-    render(<ProjectInfo {...exampleArgs}>{exampleText}</ProjectInfo>);
+    render(<ProjectInfo {...exampleArgs}>{exampleArgs.children}</ProjectInfo>);
     const heading = screen.getByRole("heading", {
       level: 2,
       name: exampleArgs.title,
@@ -20,23 +22,25 @@ describe("ProjectInfo component", () => {
     expect(heading).toBeInTheDocument();
   });
   it("should render its children (aka. text content)", () => {
-    render(<ProjectInfo {...exampleArgs}>{exampleText}</ProjectInfo>);
-    const childrenText = screen.getByText(exampleText);
+    render(<ProjectInfo {...exampleArgs}>{exampleArgs.children}</ProjectInfo>);
+    const childrenText = screen.getByText(/Description/i);
     expect(childrenText).toBeInTheDocument();
   });
   it("should display a category tag", () => {
-    render(<ProjectInfo {...exampleArgs}>{exampleText}</ProjectInfo>);
+    render(<ProjectInfo {...exampleArgs}>{exampleArgs.children}</ProjectInfo>);
     const category = screen.getByText(exampleArgs.category);
     expect(category).toBeInTheDocument();
   });
-  it("should display a link to the edit project route", () => {
-    render(<ProjectInfo {...exampleArgs}>{exampleText}</ProjectInfo>);
-    const editLink = screen.getByRole("link", { name: "Projekt bearbeiten" });
-    expect(editLink).toBeInTheDocument();
-    expect(editLink.getAttribute("href")).toBe(exampleArgs.editLink);
+  it("should fire a function when 'edit project' is clicked", () => {
+    render(<ProjectInfo {...exampleArgs}>{exampleArgs.children}</ProjectInfo>);
+    const editProjectButton = screen.getByRole("button", {
+      name: /Projekt bearbeiten/i,
+    });
+    userEvent.click(editProjectButton);
+    expect(editProjectFunction).toHaveBeenCalledTimes(1);
   });
   it("should display a link to the project view route", () => {
-    render(<ProjectInfo {...exampleArgs}>{exampleText}</ProjectInfo>);
+    render(<ProjectInfo {...exampleArgs}>{exampleArgs.children}</ProjectInfo>);
     const projectViewLink = screen.getByRole("link", {
       name: "→ Projektseite",
     });

--- a/src/components/ProjectInfo/__snapshots__/ProjectInfo.stories.storyshot
+++ b/src/components/ProjectInfo/__snapshots__/ProjectInfo.stories.storyshot
@@ -18,8 +18,10 @@ exports[`Storyshots Layout/ProjectInfo Default Project Info 1`] = `
       Temperatur Grunewaldstraße
     </h2>
     <a
-      className="p-2 border border-blue-500 text-blue-500 hover:bg-blue-50 transition-colors"
+      className="px-4 py-2 font-sans text-lg transition cursor-pointer focus-offset bg-white border border-blue-500 text-blue-500 hover:bg-blue-500 hover:bg-opacity-10"
       href="/123abc"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
     >
       → Projektseite
     </a>
@@ -34,21 +36,17 @@ exports[`Storyshots Layout/ProjectInfo Default Project Info 1`] = `
         Temperatur
       </mark>
     </p>
-    <p
-      className="mt-4"
+    <div
+      className="mt-4 max-w-prose"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-    </p>
-    <p
-      className="mt-4"
+    </div>
+    <button
+      className="mt-4 text-blue-500 underline hover:text-opacity-60 transition-colors focus-offset"
+      onClick={[Function]}
     >
-      <a
-        className="text-blue-500 hover:text-blue-400 underline transition-colors"
-        href="/123abc/edit"
-      >
-        Projekt bearbeiten
-      </a>
-    </p>
+      Projekt bearbeiten
+    </button>
   </div>
 </section>
 `;

--- a/src/components/ProjectInfo/index.tsx
+++ b/src/components/ProjectInfo/index.tsx
@@ -1,10 +1,12 @@
 import { FC, ReactNode } from "react";
+import Link from "next/link";
+import { Anchor } from "@components/Button";
 
 export interface ProjectInfoPropType {
   title: string;
   category: string;
   projectViewLink: string;
-  editLink: string;
+  onEditProject: () => void;
   children: ReactNode;
 }
 
@@ -12,7 +14,7 @@ export const ProjectInfo: FC<ProjectInfoPropType> = ({
   title,
   category,
   projectViewLink,
-  editLink,
+  onEditProject,
   children,
 }) => (
   <section className='bg-blue-25 p-6'>
@@ -21,12 +23,9 @@ export const ProjectInfo: FC<ProjectInfoPropType> = ({
       style={{ gridTemplateColumns: "auto max-content" }}
     >
       <h2 className='text-blue-500 text-3xl font-bold'>{title}</h2>
-      <a
-        href={projectViewLink}
-        className='p-2 border border-blue-500 text-blue-500 hover:bg-blue-50 transition-colors'
-      >
-        → Projektseite
-      </a>
+      <Link href={projectViewLink}>
+        <Anchor href={projectViewLink}>→ Projektseite</Anchor>
+      </Link>
     </header>
     <div className='mt-4'>
       <p>
@@ -34,15 +33,13 @@ export const ProjectInfo: FC<ProjectInfoPropType> = ({
           {category}
         </mark>
       </p>
-      <p className='mt-4'>{children}</p>
-      <p className='mt-4'>
-        <a
-          href={editLink}
-          className='text-blue-500 hover:text-blue-400 underline transition-colors'
-        >
-          Projekt bearbeiten
-        </a>
-      </p>
+      <div className='mt-4 max-w-prose'>{children}</div>
+      <button
+        onClick={onEditProject}
+        className='mt-4 text-blue-500 underline hover:text-opacity-60 transition-colors focus-offset'
+      >
+        Projekt bearbeiten
+      </button>
     </div>
   </section>
 );


### PR DESCRIPTION
This PR makes a small update to the `ProjectInfo` section: "Projekt bearbeiten" now fires a function instead of linking to another route.