### PR TITLE
chore(nav): use new authenticated routes

### DIFF
--- a/src/components/AuthLink/index.tsx
+++ b/src/components/AuthLink/index.tsx
@@ -60,8 +60,8 @@ export const AuthLink: FC = () => {
   ) : (
     <DropdownMenu
       items={[
-        { id: 1, title: "Meine Projekte", href: "/projects" },
-        { id: 2, title: "Account", href: "/account" },
+        { id: 1, title: "Meine Projekte", href: "/account/projects" },
+        { id: 2, title: "Account", href: "/account/profile" },
         { id: 3, title: "Logout", onClick: () => void signOut() },
       ]}
     >


### PR DESCRIPTION
This PR updates the href's of the authenticated nav according to the agreed-upon routes:

- "Meine Projekte": `/account/projects` (which would be redirected to `/account/projects/[id]`)
- "Account": `/account/profile`