### PR TITLE
refactor(UserProjectsWrapper): align projects title with project title

### DIFF
--- a/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
+++ b/src/components/UserProjectsWrapper/__snapshots__/UserProjectsWrapper.stories.storyshot
@@ -13,7 +13,7 @@ exports[`Storyshots Layout/UserProjectsWrapper Default 1`] = `
     className="col-span-4"
   >
     <h1
-      className="text-3xl text-blue-500 font-bold"
+      className="text-3xl text-blue-500 font-bold mt-6"
     >
       Meine Projekte
     </h1>

--- a/src/components/UserProjectsWrapper/index.tsx
+++ b/src/components/UserProjectsWrapper/index.tsx
@@ -28,7 +28,9 @@ export const UserProjectsWrapper: FC<UserProjectWrapperType> = ({
       style={{ paddingTop: "5vmax" }}
     >
       <section className='col-span-4'>
-        <h1 className='text-3xl text-blue-500 font-bold'>Meine Projekte</h1>
+        <h1 className='text-3xl text-blue-500 font-bold mt-6'>
+          Meine Projekte
+        </h1>
         <div className='mt-8'>
           <Link href={"/account/projects/new"}>
             <Anchor href={"/account/projects/new"} variant='primary'>


### PR DESCRIPTION
This PR just add a margin-top to the headline "Meine Projekte" so that it aligns well visually with the selected project's headline (see screenshot).

<img width="1165" alt="Screen Shot 2021-04-21 at 22 55 08" src="https://user-images.githubusercontent.com/2759340/115620295-49932780-a2f5-11eb-802f-833e40bb1dbd.png">
