### PR TITLE
Add `useProjectTokens` hook with tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ NEXT_PUBLIC_MAPBOX_TOKEN=MAPBOX_TOKEN_HERE
 NEXT_PUBLIC_WEB_URL="http://localhost:3000" # For production, use your production URL
 NEXT_PUBLIC_SUPABASE_URL="https://YOUR_SUPABASE_URL.supabase.co"
 NEXT_PUBLIC_SUPABASE_PUBLIC_KEY="eyJKhbGciOisJIUzI1Nd2iIsInR5cCsI6..."
+NEXT_PUBLIC_TOKEN_API_URL="https://my-token-api.com"

--- a/src/lib/hooks/useProjectTokens/index.ts
+++ b/src/lib/hooks/useProjectTokens/index.ts
@@ -1,0 +1,127 @@
+import { useAuth } from "@auth/Auth";
+import { createTokenApiUrl } from "@lib/requests/createTokenApiUrl";
+import { useCallback } from "react";
+import useSWR, { mutate } from "swr";
+
+interface TokenType {
+  projectId: string;
+  description: string;
+  niceId: string;
+}
+
+type AccessTokenType = string;
+type AuthTokenType = string;
+
+interface GetTokensPayload {
+  projectId: TokenType["projectId"];
+}
+
+interface CreateTokenPayload {
+  projectId: TokenType["projectId"];
+  description: TokenType["description"];
+}
+
+type GetProjectTokensSignature = (
+  params: GetTokensPayload & {
+    accessToken: AccessTokenType;
+  }
+) => Promise<TokenType[]>;
+
+type CreateProjectTokenSignature = (
+  params: CreateTokenPayload & {
+    accessToken: AccessTokenType;
+  }
+) => Promise<string>;
+
+const createProjectToken: CreateProjectTokenSignature = async ({
+  accessToken,
+  ...payload
+}) => {
+  const myHeaders = new Headers();
+  myHeaders.append("Authorization", `Bearer ${accessToken}`);
+  myHeaders.append("Content-Type", "application/json");
+
+  const requestOptions = {
+    method: "POST",
+    headers: myHeaders,
+    redirect: "follow" as const,
+    body: JSON.stringify(payload),
+  };
+
+  const rawToken = await fetch(createTokenApiUrl(), requestOptions);
+  const stringToken = await rawToken.text();
+  return stringToken;
+};
+
+const getProjectTokens: GetProjectTokensSignature = async ({
+  accessToken,
+  projectId,
+}) => {
+  const myHeaders = new Headers();
+  myHeaders.append("Authorization", `Bearer ${accessToken}`);
+  myHeaders.append("Content-Type", "application/json");
+
+  const requestOptions = {
+    method: "GET",
+    headers: myHeaders,
+    redirect: "follow" as const,
+  };
+
+  const url = createTokenApiUrl({ projectId });
+  const rawTokens = await fetch(url, requestOptions);
+  const response = await (rawTokens.json() as Promise<{
+    data: TokenType[];
+  }>);
+  return response.data;
+};
+
+const getTokensSWRFetcher = async (
+  projectId: TokenType["projectId"],
+  accessToken: AccessTokenType | null
+): Promise<TokenType[] | null> => {
+  if (!accessToken) return null;
+  return getProjectTokens({
+    accessToken,
+    projectId,
+  });
+};
+
+interface ProjectTokensHookReturnType {
+  tokens: TokenType[] | null;
+  error: Error | null;
+  createToken: (
+    description: TokenType["description"]
+  ) => Promise<AuthTokenType>;
+}
+
+export const useProjectTokens = (
+  projectId: number
+): ProjectTokensHookReturnType => {
+  const { accessToken } = useAuth();
+  const tokensParams = [`use-tokens-${projectId}`, accessToken];
+  const { data: tokens, error } = useSWR<TokenType[] | null, Error>(
+    tokensParams,
+    () => getTokensSWRFetcher(`${projectId}`, accessToken)
+  );
+
+  const createToken = useCallback(
+    async (description: string) => {
+      if (!accessToken)
+        throw new Error("Invalid accessToken while creating a token");
+      const token = await createProjectToken({
+        projectId: String(projectId),
+        description,
+        accessToken,
+      });
+      await mutate([`use-tokens-${projectId}`, accessToken]);
+      return token;
+    },
+    [accessToken, projectId]
+  );
+
+  return {
+    tokens: tokens || null,
+    error: error || null,
+    createToken: createToken,
+  };
+};

--- a/src/lib/hooks/useProjectTokens/useProjectTokens.test.tsx
+++ b/src/lib/hooks/useProjectTokens/useProjectTokens.test.tsx
@@ -1,0 +1,157 @@
+import { FC, useEffect } from "react";
+import { render, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import { useProjectTokens } from ".";
+import { server } from "@mocks/server";
+import { SWRConfig } from "swr";
+import * as auth from "@auth/Auth";
+
+type DataType = ReturnType<typeof useProjectTokens>["tokens"];
+type OnLoadTokensSuccessType = (data: DataType) => void;
+type OnLoadTokensFailType = (error: string) => void;
+type OnCreateTokensSuccessType = (token: string) => void;
+type OnCreateTokensFailType = (error: string) => void;
+
+const createTestComponent = (
+  onSuccess: OnLoadTokensSuccessType = jest.fn(),
+  onFail: OnLoadTokensFailType = jest.fn(),
+  onTokenCreationSuccess: OnCreateTokensSuccessType = jest.fn(),
+  onTokenCreationFail: OnCreateTokensFailType = jest.fn()
+): FC => {
+  const TestComponent: FC = () => {
+    const { tokens, error, createToken } = useProjectTokens(10);
+
+    useEffect(() => {
+      if (tokens && !error) onSuccess(tokens);
+      if (error) onFail(error.message);
+    }, [tokens, error, createToken]);
+
+    useEffect(() => {
+      const localCreateToken = async (): Promise<void> => {
+        try {
+          const token = await createToken("test");
+          onTokenCreationSuccess(token);
+        } catch (err) {
+          onTokenCreationFail(new Error(err).message);
+        }
+      };
+      void localCreateToken();
+    }, [createToken]);
+
+    if (!tokens && !error) return <p>Loading</p>;
+    if (error) return <p>Error</p>;
+    return (
+      <p>{tokens && tokens.length ? tokens[0].description : "no categories"}</p>
+    );
+  };
+  return TestComponent;
+};
+
+const originalUseAuth = auth.useAuth;
+describe("useProjectTokens", () => {
+  beforeEach(() => {
+    // Ingored because of readonly reassignment for mocking purposes
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    auth.useAuth = jest.fn().mockReturnValue({ accessToken: "12345" });
+  });
+
+  afterEach(() => {
+    // Ingored because of readonly reassignment for mocking purposes
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    auth.useAuth = originalUseAuth;
+  });
+  it("should get the project tokens", async (): Promise<void> => {
+    const onSuccess = jest.fn();
+    const onSuccessWrapper = (tokens: DataType): void => {
+      onSuccess(tokens);
+    };
+    const onError = jest.fn();
+    const TestComponent = createTestComponent(onSuccessWrapper, onError);
+
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <TestComponent />
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should return an error if network has error", async (): Promise<void> => {
+    server.use(rest.get("*", (_req, res) => res.networkError("Error")));
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+    const onErrorWrapper = (error: string): void => {
+      onError(error ? true : false);
+    };
+    const TestComponent = createTestComponent(onSuccess, onErrorWrapper);
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <TestComponent />
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenLastCalledWith(true);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+  it("should create a token", async (): Promise<void> => {
+    const onCreateSuccess = jest.fn();
+    const onCreateError = jest.fn();
+    const onCreateSuccessWrapper = (token: string): void => {
+      onCreateSuccess(token ? true : false);
+    };
+
+    const TestComponent = createTestComponent(
+      undefined,
+      undefined,
+      onCreateSuccessWrapper,
+      onCreateError
+    );
+
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <TestComponent />
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(onCreateSuccess).toHaveBeenLastCalledWith(true);
+      expect(onCreateError).not.toHaveBeenCalled();
+    });
+  });
+  it("should fail to create a token if no access token", async (): Promise<void> => {
+    // Ingored because of readonly reassignment for mocking purposes
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    auth.useAuth = jest.fn().mockReturnValue({ accessToken: null });
+    const onCreateSuccess = jest.fn();
+    const onCreateError = jest.fn();
+
+    const TestComponent = createTestComponent(
+      undefined,
+      undefined,
+      onCreateSuccess,
+      onCreateError
+    );
+
+    render(
+      <SWRConfig value={{ dedupingInterval: 0 }}>
+        <TestComponent />
+      </SWRConfig>
+    );
+
+    await waitFor(() => {
+      expect(onCreateError).toHaveBeenLastCalledWith(
+        "Error: Invalid accessToken while creating a token"
+      );
+      expect(onCreateSuccess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/requests/createTokenApiUrl/createTokenApiUrl.test.ts
+++ b/src/lib/requests/createTokenApiUrl/createTokenApiUrl.test.ts
@@ -1,0 +1,15 @@
+import { createTokenApiUrl } from ".";
+describe("utility function createTokenApiUrl", () => {
+  it("should include the authtokens route", () => {
+    const url = createTokenApiUrl();
+    expect(url.includes("/api/v2/authtokens")).toBe(true);
+  });
+  it("should not include undefined", () => {
+    const url = createTokenApiUrl();
+    expect(url.includes("undefined")).toBe(false);
+  });
+  it("should include the provided parameters", () => {
+    const url = createTokenApiUrl({ thisIsSo: "cool" });
+    expect(url.includes("?thisIsSo=cool")).toBe(true);
+  });
+});

--- a/src/lib/requests/createTokenApiUrl/index.ts
+++ b/src/lib/requests/createTokenApiUrl/index.ts
@@ -1,0 +1,15 @@
+export const createTokenApiUrl = (params?: Record<string, string>): string => {
+  const url = new URL(
+    `${
+      process.env.NEXT_PUBLIC_TOKEN_API_URL || "https://fake-token-api-url.com"
+    }/api/v2/authtokens`
+  );
+
+  if (params) {
+    Object.keys(params).forEach(key => {
+      url.searchParams.append(key, params[key]);
+    });
+  }
+
+  return url.href;
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -16,6 +16,7 @@ import {
 import { createV1ApiUrl } from "../lib/requests/createV1ApiUrl";
 import { createV2ApiUrl } from "../lib/requests/createV2ApiUrl";
 import { getSupabaseCredentials } from "../auth/supabase";
+import { createTokenApiUrl } from "@lib/requests/createTokenApiUrl";
 
 const { data: projectsData } = projectsResponse;
 const { data: project1DevicesData } = project1Devices;
@@ -24,6 +25,29 @@ const { data: device1RecordsData } = device1Records;
 const { data: device2RecordsData } = device2Records;
 const { data: device3RecordsData } = device3Records;
 const { data: device4RecordsData } = device4Records;
+
+const tokenApiHandlers = [
+  rest.get(createTokenApiUrl({ projectId: "10" }), (_req, res, ctx) => {
+    return res(
+      ctx.status(201, "Mocked status"),
+      ctx.json({
+        data: [
+          { niceId: 1, description: "Lorem ipsum dolor.", projectId: 10 },
+          { niceId: 2, description: "Sit amet consectetur.", projectId: 10 },
+          { niceId: 3, description: "Lipsum amet dolor.", projectId: 10 },
+        ],
+      })
+    );
+  }),
+  rest.post(createTokenApiUrl(), (_req, res, ctx) => {
+    return res(
+      ctx.status(201, "Mocked status"),
+      ctx.text(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjYTNmMjY3My0wNWNkLTRiNjMtYTJiZC1lZjhmYWY5MzFlZWYiLCJwcm9qZWN0SWQiOjEwLCJkZXNjcmlwdGlvbiI6Im15IGZhbmN5IHRva2VuIiwianRpIjoiOTlmMGNjY2EtYTA3MC00MjBmLTk0N2EtZDk3Y2QxYTAzN2RmIiwiaXNzIjoidGVjaG5vbG9naWVzdGlmdHVuZy1iZXJsaW4uZGUiLCJpYXQiOjE2MTkwNzkzOTB9.IBZ4qrsi8ibAUcUi8LsZtiWSE1Q5DzjFJZMPwzMZrKA"
+      )
+    );
+  }),
+];
 
 const supabaseHandlers = [
   rest.get(createV2ApiUrl("/categories"), (_req, res, ctx) => {
@@ -145,4 +169,9 @@ const authHandlers = [
   }),
 ];
 
-export const handlers = [...apiHandlers, ...supabaseHandlers, ...authHandlers];
+export const handlers = [
+  ...apiHandlers,
+  ...supabaseHandlers,
+  ...authHandlers,
+  ...tokenApiHandlers,
+];


### PR DESCRIPTION
This PR adds a hook called `useProjectTokens` that can be initialized with a `projectId` and return 3 things:
1. A tokens property that is either `null` or an array of tokens
2. An error object that is either there or `null`
3. A `createToken` function that creates a new token for the relevant project and returns an AuthToken string