### PR TITLE
fix(DATAHUB-305): ensure Dropdown opacity classes don't collide

### DIFF
--- a/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
+++ b/src/components/Dropdown/__snapshots__/Dropdown.stories.storyshot
@@ -16,7 +16,7 @@ exports[`Storyshots UI Elements/Dropdown Default 1`] = `
   </button>
   <span
     aria-hidden={true}
-    className="absolute top-full left-1 w-3 h-3 bg-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0 opacity-0"
+    className="absolute top-full left-1 w-3 h-3 bg-white border border-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0"
   />
   <section
     className="absolute top-full left-0 transform transition whitespace-nowrap pt-3 w-auto max-width-md transform-y-4 opacity-0 pointer-events-none"

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -15,16 +15,16 @@ export const Dropdown: FC<DropdownPropType> = ({
   const ref = useClickOutside<HTMLButtonElement>(() => setIsVisible(false));
   const dropdownStyles = [
     "absolute top-full left-0 transform transition whitespace-nowrap pt-3",
-    "w-auto max-width-md transform-y-4 opacity-0",
+    "w-auto max-width-md transform-y-4",
     position === "right" && "-translate-x-3/4",
-    !isVisible && "pointer-events-none",
+    !isVisible && "opacity-0 pointer-events-none",
     isVisible && "transform-y-0 opacity-100 pointer-events-all",
   ]
     .filter(Boolean)
     .join(" ");
   const caretStyles = [
-    "absolute top-full left-1 w-3 h-3 bg-gray-200 shadow transition",
-    "transform rotate-45 translate-y-2 opacity-0",
+    "absolute top-full left-1 w-3 h-3 bg-white border border-gray-200 shadow transition",
+    "transform rotate-45 translate-y-2",
     isVisible ? "opacity-100" : "opacity-0",
   ]
     .filter(Boolean)

--- a/src/components/DropdownMenu/__snapshots__/DropdownMenu.stories.storyshot
+++ b/src/components/DropdownMenu/__snapshots__/DropdownMenu.stories.storyshot
@@ -16,7 +16,7 @@ exports[`Storyshots UI Elements/DropdownMenu Default 1`] = `
   </button>
   <span
     aria-hidden={true}
-    className="absolute top-full left-1 w-3 h-3 bg-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0 opacity-0"
+    className="absolute top-full left-1 w-3 h-3 bg-white border border-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0"
   />
   <section
     className="absolute top-full left-0 transform transition whitespace-nowrap pt-3 w-auto max-width-md transform-y-4 opacity-0 pointer-events-none"
@@ -71,7 +71,7 @@ exports[`Storyshots UI Elements/DropdownMenu With Custom Children 1`] = `
   </button>
   <span
     aria-hidden={true}
-    className="absolute top-full left-1 w-3 h-3 bg-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0 opacity-0"
+    className="absolute top-full left-1 w-3 h-3 bg-white border border-gray-200 shadow transition transform rotate-45 translate-y-2 opacity-0"
   />
   <section
     className="absolute top-full left-0 transform transition whitespace-nowrap pt-3 w-auto max-width-md transform-y-4 opacity-0 pointer-events-none"


### PR DESCRIPTION
This PR fixes the bug that currently when logged in, we cannot access the user nav because the classes `opacity-0` and `opacity-100` are simultaneously present and `opacity-0` takes precedence which results in the dropdown being invisible.

In this PR it is ensured that the classes cannot exist at the same time.