### PR TITLE
fix(STADTPULS-268): Snap tooltip to nearest datapoint

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,7 @@ import "../src/style/global.css";
 import { Head } from "@components/Head";
 
 if (process.env.NODE_ENV !== "production") {
-  require("../src/mocks/index");
+  // require("../src/mocks/sindex");
 }
 
 const App: FC<{

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -95,7 +95,7 @@ export const LineChart = withTooltip<LineGraphType, DateValueType>(
         }
         showTooltip({
           tooltipData: d,
-          tooltipLeft: x,
+          tooltipLeft: xScale(getX(d)) + padding.left,
           tooltipTop: yScale(getY(d)),
         });
       },

--- a/src/components/SensorsList/__snapshots__/SensorsList.stories.storyshot
+++ b/src/components/SensorsList/__snapshots__/SensorsList.stories.storyshot
@@ -195,7 +195,7 @@ exports[`Storyshots Layout/SensorsList Default 1`] = `
               }
             }
           >
-            Vor 6 Monaten
+            Vor 7 Monaten
           </td>
           <td
             className="sm:text-right sm:py-3 pl-8 sm:pl-2 sm:pr-6 whitespace-nowrap w-auto block align-top sm:table-cell font-normal"


### PR DESCRIPTION
This PR makes sure that line chart tooltips always snap to the nearest datapoint.