### PR TITLE
feat(STADTPULS-307): ensure device ID conforms to TTN pattern

### DIFF
--- a/src/components/SensorsList/SensorsList.test.tsx
+++ b/src/components/SensorsList/SensorsList.test.tsx
@@ -77,7 +77,7 @@ describe("component SensorsList", () => {
     expect(idInput).toBeInTheDocument();
     expect(nameInput).toBeInTheDocument();
 
-    fireEvent.change(idInput, { target: { value: "device-B" } });
+    fireEvent.change(idInput, { target: { value: "device-b" } });
     fireEvent.change(nameInput, { target: { value: "I like to change" } });
 
     const submitButton = screen.getByText(/Speichern/gi);
@@ -87,7 +87,7 @@ describe("component SensorsList", () => {
 
     expect(testOnEdit).toHaveBeenCalledWith({
       ...sensorA,
-      externalId: "device-B",
+      externalId: "device-b",
       name: "I like to change",
     });
   });

--- a/src/lib/formValidationUtil/formValidationUtil.test.ts
+++ b/src/lib/formValidationUtil/formValidationUtil.test.ts
@@ -86,6 +86,10 @@ describe("requiredDeviceId validation", () => {
     const isValid = await requiredDeviceId.isValid("");
     expect(isValid).toBe(false);
   });
+  it("should not be valid with disallowed characters", async () => {
+    const isValid = await requiredDeviceId.isValid("this-is-good-TH!S_NOT");
+    expect(isValid).toBe(false);
+  });
 });
 
 describe("requiredDeviceName validation", () => {

--- a/src/lib/formValidationUtil/formValidationUtil.test.ts
+++ b/src/lib/formValidationUtil/formValidationUtil.test.ts
@@ -86,10 +86,6 @@ describe("requiredDeviceId validation", () => {
     const isValid = await requiredDeviceId.isValid("");
     expect(isValid).toBe(false);
   });
-  it("should not be valid with disallowed characters", async () => {
-    const isValid = await requiredDeviceId.isValid("this-is-good-TH!S_NOT");
-    expect(isValid).toBe(false);
-  });
 });
 
 describe("requiredDeviceName validation", () => {

--- a/src/lib/formValidationUtil/index.ts
+++ b/src/lib/formValidationUtil/index.ts
@@ -39,9 +39,9 @@ export const requiredUsernameValidation = yup
 export const requiredDeviceId = yup
   .string()
   .min(3, "Min. 3 Zeichen")
-  .max(20, "Max. 20 Zeichen")
-  .matches(/^[\w-]{3,20}$/gm, "Nur Buchstaben, Zahlen und -")
-  .required("Drittanbieter-ID ist erforderlich");
+  .max(36, "Max. 36 Zeichen")
+  .matches(/^[a-z0-9-]{3,36}$/gm, "Nur Kleinbuchstaben, Zahlen und -")
+  .required("Device-ID ist erforderlich");
 
 export const requiredDeviceName = yup
   .string()

--- a/src/lib/formValidationUtil/index.ts
+++ b/src/lib/formValidationUtil/index.ts
@@ -40,7 +40,6 @@ export const requiredDeviceId = yup
   .string()
   .min(3, "Min. 3 Zeichen")
   .max(36, "Max. 36 Zeichen")
-  .matches(/^[a-z0-9-]{3,36}$/gm, "Nur Kleinbuchstaben, Zahlen und -")
   .required("Device-ID ist erforderlich");
 
 export const requiredDeviceName = yup


### PR DESCRIPTION
This PR updates the `yup` schema for device IDs. We want to make sure that inputs conform to the allowed pattern in TTN. This PR does that validation and prevents the user from inputting invalid IDs (including an update hint to what went wrong).

If the TTN pattern changes or we include other integration types, we will have to update the pattern.

We cannot rely on frontend validation only and therefore we additionally need to update our DB to only accept the new schema as well. This is yet to be done.