### PR TITLE
fix(STADTPULS-296): add UTC indicator

### DIFF
--- a/src/components/DataTable/__snapshots__/DataTable.stories.storyshot
+++ b/src/components/DataTable/__snapshots__/DataTable.stories.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots UI Elements/DataTable Default 1`] = `
           <th
             className="py-2 px-1 font-normal text-left"
           >
-            Uhrzeit
+            Uhrzeit (UTC)
           </th>
           <th
             className="py-2 px-1 font-normal text-right"

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -74,7 +74,7 @@ export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
               <th
                 className={["py-2 px-1", "font-normal", "text-left"].join(" ")}
               >
-                Uhrzeit
+                Uhrzeit (UTC)
               </th>
               <th
                 className={["py-2 px-1", "font-normal", "text-right"].join(" ")}

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -225,7 +225,7 @@ export const LineChart = withTooltip<LineGraphType, DateValueType>(
               }}
               className='text-gray-900'
             >
-              {formatDate(getX(tooltipData))}
+              {formatDate(getX(tooltipData))} (UTC)
             </TooltipWithBounds>
           </div>
         )}


### PR DESCRIPTION
This is a small hotfix for STADTPULS-296. To make it understandable that we currently parse all dates/times as UTC, we should also make that clear in the UI. This way, you at least understand why e.g. your values from Berlin are 2hrs off at the moment.

This solution is not ideal, but currently we receive all records as UTC time anyway, no matter where the device is located.