### PR TITLE
fix(STADTPULS-311): get correct lastRecordedAt

### DIFF
--- a/src/components/SensorsList/WithData/WithData.test.tsx
+++ b/src/components/SensorsList/WithData/WithData.test.tsx
@@ -1,0 +1,45 @@
+import { DevicesType } from "@common/types/supabase";
+import moment from "moment";
+import { render, screen } from "@testing-library/react";
+import { SensorsListWithData as SensorsList } from ".";
+
+const defaults = {
+  onChange: jest.fn(),
+  onAdd: jest.fn(),
+  onDelete: jest.fn(),
+  projectId: 1,
+};
+const createSensor = (key: number): DevicesType => ({
+  id: key,
+  externalId: `device-${key}`,
+  name: `My sensor ${key}`,
+  projectId: defaults.projectId,
+  records: [
+    {
+      id: 1,
+      deviceId: key,
+      recordedAt: moment().subtract(20, "minutes").toISOString(),
+    },
+    {
+      id: 2,
+      deviceId: key,
+      recordedAt: moment().subtract(10, "minutes").toISOString(),
+    },
+    {
+      id: 3,
+      deviceId: key,
+      recordedAt: moment().subtract(5, "minutes").toISOString(),
+    },
+  ],
+});
+
+describe("component SensorsListWithData", () => {
+  it("returns the most recent date", () => {
+    render(<SensorsList {...defaults} devices={[createSensor(1)]} />);
+    const lastRecordedAt = screen.getByText(/Vor 5 Minuten/i);
+    expect(lastRecordedAt).toBeInTheDocument();
+
+    expect(screen.queryByText(/Vor 10 Minuten/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Vor 20 Minuten/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/SensorsList/WithData/index.tsx
+++ b/src/components/SensorsList/WithData/index.tsx
@@ -10,7 +10,7 @@ const getLastRecordedAt = (records: RecordsType[]): Date | null => {
       ...record,
       recordedAt: new Date(record.recordedAt),
     }))
-    .sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
+    .sort((a, b) => b.recordedAt.getTime() - a.recordedAt.getTime());
 
   if (sortedRecords.length === 0) return null;
   return sortedRecords[0].recordedAt;


### PR DESCRIPTION
This PR fixes the sorting of dates in the `SensorsListWithData`.

---

- [x] fix the sorting
- [x] add a test for the function that caused the issue