### PR TITLE
fix(Project): Set last 7 days of records as default time range

### DIFF
--- a/src/components/Project/index.tsx
+++ b/src/components/Project/index.tsx
@@ -88,6 +88,16 @@ export const Project: FC<ProjectsType> = project => {
   > | null>(null);
 
   useEffect(() => {
+    if (!lastRecordDate) return;
+    setCurrentDatetimeRange({
+      startDateTimeString: moment(lastRecordDate)
+        .subtract(7, "days")
+        .toISOString(),
+      endDateTimeString: moment(lastRecordDate).toISOString(),
+    });
+  }, [lastRecordDate, setCurrentDatetimeRange]);
+
+  useEffect(() => {
     const devicesWithCoordinates = project?.devices?.filter(device => {
       return (
         Boolean(device?.records?.[0]?.latitude) &&


### PR DESCRIPTION
This PR sets the last 7 days in which records were recorded as the default time range as discussed with @dnsos and @edgalindo. This ensures that, as long as a sensor recorded some data, this data will be shown and an empty chart is avoided.