### PR TITLE
fix(FormSelect): Fix select's wrong value

### DIFF
--- a/src/components/CreateProjectForm/__snapshots__/CreateProjectForm.stories.storyshot
+++ b/src/components/CreateProjectForm/__snapshots__/CreateProjectForm.stories.storyshot
@@ -45,7 +45,6 @@ exports[`Storyshots Forms/CreateProjectForm Default 1`] = `
       </label>
       <select
         className="mb-2 text-gray-500 "
-        defaultValue="Bitte wähle eine Option"
         id="categoryId"
         name="categoryId"
         onBlur={[Function]}
@@ -134,7 +133,6 @@ exports[`Storyshots Forms/CreateProjectForm Default 1`] = `
       </label>
       <select
         className="mb-2 text-gray-500 "
-        defaultValue="Wie möchtest du dein Projekt integrieren?"
         id="connectype"
         name="connectype"
         onBlur={[Function]}

--- a/src/components/EditProjectForm/__snapshots__/EditProjectForm.stories.storyshot
+++ b/src/components/EditProjectForm/__snapshots__/EditProjectForm.stories.storyshot
@@ -45,18 +45,13 @@ exports[`Storyshots Forms/EditProjectForm With Default Values 1`] = `
       </label>
       <select
         className="mb-2 text-blue "
-        defaultValue="3"
         id="categoryId"
         name="categoryId"
         onBlur={[Function]}
         onChange={[Function]}
         required={true}
+        value={3}
       >
-        <option
-          value=""
-        >
-          Bitte wähle eine Option
-        </option>
         <option
           value="1"
         >
@@ -204,7 +199,6 @@ exports[`Storyshots Forms/EditProjectForm Without Default Values 1`] = `
       </label>
       <select
         className="mb-2 text-gray-500 "
-        defaultValue="Bitte wähle eine Option"
         id="categoryId"
         name="categoryId"
         onBlur={[Function]}

--- a/src/components/FormSelect/FormSelect.stories.tsx
+++ b/src/components/FormSelect/FormSelect.stories.tsx
@@ -23,10 +23,7 @@ const Template: Story<{
       {
         required: true,
         min: 20,
-        onChange: evt =>
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          action(`Select "${args.name}" changed`)(evt.target.value),
+        onChange: val => action(`Select "${args.name}" changed`)(val),
       })}
       {...args}
     />
@@ -40,15 +37,15 @@ WithLabel.args = {
   options: [
     {
       name: "First option",
-      value: "First option",
+      value: "first_option",
     },
     {
       name: "Second option",
-      value: "Second option",
+      value: "second_option",
     },
     {
       name: "Third option",
-      value: "Third option",
+      value: "third_option",
     },
   ],
 };
@@ -59,15 +56,15 @@ WithoutLabel.args = {
   options: [
     {
       name: "First option",
-      value: "First option",
+      value: "first_option",
     },
     {
       name: "Second option",
-      value: "Second option",
+      value: "second_option",
     },
     {
       name: "Third option",
-      value: "Third option",
+      value: "third_option",
     },
   ],
 };
@@ -79,15 +76,15 @@ WithCustomPlaceholder.args = {
   options: [
     {
       name: "First option",
-      value: "First option",
+      value: "first_option",
     },
     {
       name: "Second option",
-      value: "Second option",
+      value: "second_option",
     },
     {
       name: "Third option",
-      value: "Third option",
+      value: "third_option",
     },
   ],
 };
@@ -98,15 +95,15 @@ WithErrors.args = {
   options: [
     {
       name: "First option",
-      value: "First option",
+      value: "first_option",
     },
     {
       name: "Second option",
-      value: "Second option",
+      value: "second_option",
     },
     {
       name: "Third option",
-      value: "Third option",
+      value: "third_option",
     },
   ],
   errors: ["This is an error message", "This is another error message"],

--- a/src/components/FormSelect/__snapshots__/FormSelect.stories.storyshot
+++ b/src/components/FormSelect/__snapshots__/FormSelect.stories.storyshot
@@ -6,11 +6,9 @@ exports[`Storyshots Forms/FormSelect With Custom Placeholder 1`] = `
 >
   <select
     className="mb-2 text-gray-500 "
-    defaultValue="This is a custom placeholder"
     id="Select with custom placeholder"
     min={20}
     name="Select with custom placeholder"
-    onBlur={[Function]}
     onChange={[Function]}
     required={true}
   >
@@ -20,17 +18,17 @@ exports[`Storyshots Forms/FormSelect With Custom Placeholder 1`] = `
       This is a custom placeholder
     </option>
     <option
-      value="First option"
+      value="first_option"
     >
       First option
     </option>
     <option
-      value="Second option"
+      value="second_option"
     >
       Second option
     </option>
     <option
-      value="Third option"
+      value="third_option"
     >
       Third option
     </option>
@@ -44,11 +42,9 @@ exports[`Storyshots Forms/FormSelect With Errors 1`] = `
 >
   <select
     className="mb-2 text-gray-500 error"
-    defaultValue="Bitte wähle eine Option"
     id="Select with custom placeholder"
     min={20}
     name="Select with custom placeholder"
-    onBlur={[Function]}
     onChange={[Function]}
     required={true}
   >
@@ -58,17 +54,17 @@ exports[`Storyshots Forms/FormSelect With Errors 1`] = `
       Bitte wähle eine Option
     </option>
     <option
-      value="First option"
+      value="first_option"
     >
       First option
     </option>
     <option
-      value="Second option"
+      value="second_option"
     >
       Second option
     </option>
     <option
-      value="Third option"
+      value="third_option"
     >
       Third option
     </option>
@@ -98,11 +94,9 @@ exports[`Storyshots Forms/FormSelect With Label 1`] = `
   </label>
   <select
     className="mb-2 text-gray-500 "
-    defaultValue="Bitte wähle eine Option"
     id="Select with label"
     min={20}
     name="Select with label"
-    onBlur={[Function]}
     onChange={[Function]}
     required={true}
   >
@@ -112,17 +106,17 @@ exports[`Storyshots Forms/FormSelect With Label 1`] = `
       Bitte wähle eine Option
     </option>
     <option
-      value="First option"
+      value="first_option"
     >
       First option
     </option>
     <option
-      value="Second option"
+      value="second_option"
     >
       Second option
     </option>
     <option
-      value="Third option"
+      value="third_option"
     >
       Third option
     </option>
@@ -136,11 +130,9 @@ exports[`Storyshots Forms/FormSelect Without Label 1`] = `
 >
   <select
     className="mb-2 text-gray-500 "
-    defaultValue="Bitte wähle eine Option"
     id="Select without label"
     min={20}
     name="Select without label"
-    onBlur={[Function]}
     onChange={[Function]}
     required={true}
   >
@@ -150,17 +142,17 @@ exports[`Storyshots Forms/FormSelect Without Label 1`] = `
       Bitte wähle eine Option
     </option>
     <option
-      value="First option"
+      value="first_option"
     >
       First option
     </option>
     <option
-      value="Second option"
+      value="second_option"
     >
       Second option
     </option>
     <option
-      value="Third option"
+      value="third_option"
     >
       Third option
     </option>

--- a/src/components/FormSelect/index.tsx
+++ b/src/components/FormSelect/index.tsx
@@ -13,15 +13,15 @@ export interface SelectOptionType {
 }
 
 interface FormSelectPropType
-  extends Omit<HTMLProps<HTMLSelectElement>, "label" | "value"> {
+  extends Omit<HTMLProps<HTMLSelectElement>, "label" | "value" | "onChange"> {
   name: string;
   label?: ReactNode;
   placeholder?: string;
   options: SelectOptionType[];
   errors?: string[];
-  defaultValue?: string | number;
   value?: string | number;
-  onValueChange?: (name: string) => void;
+  defaultValue?: string | number;
+  onChange?: (name: string) => void;
 }
 
 // eslint-disable-next-line react/display-name
@@ -33,28 +33,26 @@ export const FormSelect = forwardRef<HTMLSelectElement, FormSelectPropType>(
       options,
       placeholder = "Bitte wähle eine Option",
       errors = [],
-      defaultValue,
       value,
-      onValueChange = () => undefined,
+      defaultValue,
+      onChange = () => undefined,
       ...selectProps
     },
     ref
   ) => {
-    const [selectValue, setSelectValue] = useState<string>(
-      `${value || defaultValue || placeholder}`
+    const [selectValue, setSelectValue] = useState<string | number | undefined>(
+      value || defaultValue
     );
-    const placeholderIsSelected =
-      selectValue === placeholder || selectValue === "";
 
     useEffect(() => {
-      defaultValue && setSelectValue(`${defaultValue}`);
-    }, [defaultValue]);
+      value && setSelectValue(`${value}`);
+    }, [value]);
 
     const handleSelect: ChangeEventHandler = evt => {
       evt.preventDefault();
       const target = evt.target as HTMLSelectElement;
-      const newVal = target.selectedOptions[0].value;
-      onValueChange ? onValueChange(newVal) : setSelectValue(newVal);
+      const newVal = target.value;
+      onChange ? onChange(newVal) : setSelectValue(newVal);
     };
 
     return (
@@ -67,6 +65,7 @@ export const FormSelect = forwardRef<HTMLSelectElement, FormSelectPropType>(
             {label}
           </label>
         )}
+        {/* eslint-disable-next-line jsx-a11y/no-onchange */}
         <select
           name={name}
           id={`${name}`}
@@ -74,13 +73,14 @@ export const FormSelect = forwardRef<HTMLSelectElement, FormSelectPropType>(
           required
           {...selectProps}
           className={`mb-2 ${
-            placeholderIsSelected ? "text-gray-500" : "text-blue"
+            !selectValue && placeholder ? "text-gray-500" : "text-blue"
           } ${errors.length ? "error" : ""}`}
-          onBlur={handleSelect}
           onChange={handleSelect}
-          defaultValue={selectValue}
+          value={selectValue}
         >
-          {!defaultValue && <option value=''>{placeholder}</option>}
+          {!selectValue && placeholder && (
+            <option value=''>{placeholder}</option>
+          )}
           {options.map(({ name, value: val }) => (
             <option value={`${val}`} key={`${val}`}>
               {name}

--- a/src/components/Project/index.tsx
+++ b/src/components/Project/index.tsx
@@ -300,8 +300,8 @@ export const Project: FC<ProjectsType> = project => {
                         value: `${device.id}`,
                         name: device.name || "Kein Titel",
                       }))}
-                      defaultValue={`${project.devices[selectedDeviceIndex].id}`}
-                      onValueChange={(name: string): void => {
+                      value={`${project.devices[selectedDeviceIndex].id}`}
+                      onChange={(name: string): void => {
                         const newIdx =
                           project?.devices?.findIndex(
                             ({ id }) => id === parseInt(name, 10)


### PR DESCRIPTION
This PR ensures that selects can be both either controlled or uncontrolled while always having a value. This is important in the case an HTML form element use the form data to `onSubmit`. In this case, every input within the form must have a valid value.