### PR TITLE
ci: use main branch for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["@inpyjamas"],
   "baseBranches": [
-    "staging" 
+    "main" 
   ]
 }


### PR DESCRIPTION
We have configured Renovate Bot to look for a `staging` branch, which doesn't exist in this repo. I would suggest we configure it so that it uses the `main` branch for now.

---

Closes #98 