### PR TITLE
feat(Page Transitions): Add nextjs-progressbar lib for page transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19711,6 +19711,14 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
+    "nextjs-progressbar": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/nextjs-progressbar/-/nextjs-progressbar-0.0.11.tgz",
+      "integrity": "sha512-4JQkUHgDG6gz5r04lW06cMerKhQeXXq1RCSz2WqHMcJCDgKLCCqRokn603LlEORNpzBEY/pTZJIOlzf2eh4mFQ==",
+      "requires": {
+        "nprogress": "^0.2.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -19973,6 +19981,11 @@
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
       }
+    },
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E="
     },
     "nth-check": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "moment": "2.29.1",
     "next-images": "1.8.1",
     "next-mdx-enhanced": "5.0.0",
+    "nextjs-progressbar": "0.0.11",
     "react": "17.0.2",
     "react-day-picker": "7.4.10",
     "react-dom": "17.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,8 @@ import { AuthProvider } from "@auth/Auth";
 import theme from "../src/style/theme";
 import "../src/style/global.css";
 import { Head } from "@components/Head";
+import NextNProgress from "nextjs-progressbar";
+import colors from "../src/style/colors";
 
 if (process.env.NODE_ENV !== "production") {
   // require("../src/mocks/index");
@@ -32,6 +34,7 @@ const App: FC<{
       <ThemeProvider theme={theme}>
         <AuthProvider>
           <Head />
+          <NextNProgress stopDelayMs={50} color={colors.green} />
           <Header />
           <main
             id={pathname?.replace(/\//gi, "") || "home"}


### PR DESCRIPTION
This last PR before my vacation (very low effort, big benefit) adds a progress bar to the top of the page when page transitions occur. This should make the process of waiting for SSR calls to be finished and the page to be transitioned more understandable and enjoyable.

Love you all ❤️ 🌴 🏖️ See you soon!