### PR TITLE
feat(STADTPULS-430): redirect to user account after signin

### DIFF
--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -1,0 +1,55 @@
+import { FC, useEffect } from "react";
+import { useRouter } from "next/router";
+import { useUserData } from "@lib/hooks/useUserData";
+import sensors from "pages/sensors";
+import { UserInfoWithData } from "@components/UserInfoHeader/withData";
+import { ParsedAccountType } from "@lib/hooks/usePublicAccounts";
+
+const AccountRedirectionPage: FC = () => {
+  const { user: loggedInAccount } = useUserData();
+  const router = useRouter();
+
+  const loggedOutFakeAccount: ParsedAccountType = {
+    id: "",
+    categories: [],
+    username: "...",
+    displayName: "Account lädt ...",
+    createdAt: "",
+    recordsCount: 0,
+    sensorsCount: 0,
+    sensors: [],
+  };
+
+  useEffect(() => {
+    if (!loggedInAccount) return;
+
+    void router.replace({
+      pathname: "/accounts/[username]",
+      query: { username: loggedInAccount.username },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loggedInAccount]);
+
+  return (
+    <>
+      <UserInfoWithData
+        routeAccount={loggedOutFakeAccount}
+        activeTab='sensors'
+      />
+      <div
+        id='tab-content'
+        role='tabpanel'
+        className={[
+          "container max-w-8xl mx-auto px-4 pt-8 pb-24 min-h-[500px]",
+          sensors.length === 0
+            ? "flex place-items-center place-content-center"
+            : "",
+        ].join(" ")}
+      >
+        <div className='text-gray-500 text-center mt-12'>Account lädt ...</div>
+      </div>
+    </>
+  );
+};
+
+export default AccountRedirectionPage;


### PR DESCRIPTION
This PR makes it possible to redirect to the user's account after clicking the magic link in the email:

- an `/account` route was added that first renders a "loading" profile
- we can set this route as the magic link redirect URL in Supabase
- once the user is authenticated, we redirect to the user's account `/account/[username]` (possible because we can retrieve the username from the `useAuth` hook)

Before merging:
- [ ] add new `/account` redirect URL to the production Supabase