### PR TITLE
fix(STADTPULS-431): always fetch most recently recorded records

### DIFF
--- a/src/lib/requests/getRecordsBySensorId/index.ts
+++ b/src/lib/requests/getRecordsBySensorId/index.ts
@@ -18,7 +18,8 @@ export const getRecordsBySensorId = async (
           .select("*")
           .eq("sensor_id", sensorId)
           .gte("recorded_at", options.startDate)
-          .lte("recorded_at", options.endDate);
+          .lte("recorded_at", options.endDate)
+          .order("recorded_at", { ascending: false });
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
 
@@ -30,7 +31,8 @@ export const getRecordsBySensorId = async (
           .from<definitions["records"]>("records")
           .select("*")
           .eq("sensor_id", sensorId)
-          .gte("recorded_at", options.startDate);
+          .gte("recorded_at", options.startDate)
+          .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
@@ -42,7 +44,8 @@ export const getRecordsBySensorId = async (
           .from<definitions["records"]>("records")
           .select("*")
           .eq("sensor_id", sensorId)
-          .lte("recorded_at", options.endDate);
+          .lte("recorded_at", options.endDate)
+          .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
@@ -53,7 +56,8 @@ export const getRecordsBySensorId = async (
         const { data: records, error } = await supabase
           .from<definitions["records"]>("records")
           .select("*")
-          .eq("sensor_id", sensorId);
+          .eq("sensor_id", sensorId)
+          .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found`);
@@ -64,7 +68,8 @@ export const getRecordsBySensorId = async (
     const { data: records, error } = await supabase
       .from<definitions["records"]>("records")
       .select("*")
-      .eq("sensor_id", sensorId);
+      .eq("sensor_id", sensorId)
+      .order("recorded_at", { ascending: false });
 
     if (error) throw error;
     if (!records) throw new Error(`No records found for sensor ID ${sensorId}`);


### PR DESCRIPTION
This PR is a small fix for the issue that our Supabase calls for sensor records were always returning the _first_ n items. In reality we always want the _most recently recorded_ items, that's why we are now using `.order("recorded_at", { ascending: false })` in our calls.

This mainly ensures that our line chart always displays the most recent records even if the max row limit of Supabase is exceeded. Previously all records that were exceeding the limit were simply not present in the response.

(Handling the max row limit is a separate task already documented in STADTPULS-318).