### PR TITLE
refactor(integrationsUtil): Create integrationsUtil to gather integration constants

### DIFF
--- a/src/components/EditAddSensorModal/index.tsx
+++ b/src/components/EditAddSensorModal/index.tsx
@@ -25,6 +25,7 @@ import { SensorSymbol } from "@components/SensorSymbol";
 import { InteractiveMapProps } from "react-map-gl/src/components/interactive-map";
 import GrabbingHandIcon from "../../../public/images/icons/16px/grabbingHand.svg";
 import { ParsedSensorType } from "@lib/hooks/usePublicSensors";
+import { integrations, IntegrationType } from "@lib/integrationsUtil";
 
 type FormDataType = Pick<
   ParsedSensorType,
@@ -88,7 +89,7 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
     resolver: yupResolver(formSchema),
   });
   const [connectionType, setConnectionType] = useState(
-    defaultValues.connectionType || "http"
+    defaultValues.connectionType || integrations[0]
   );
   const [viewport, setViewport] = useState<Partial<InteractiveMapProps>>({
     latitude: defaultValues?.latitude || DEFAULT_LAT,
@@ -257,14 +258,14 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
                   {...field}
                   onChange={newValue => {
                     field.onChange(newValue);
-                    setConnectionType(newValue as "http" | "ttn");
+                    setConnectionType(newValue as IntegrationType);
                   }}
                   label='Integration'
                   placeholder='Wie möchtest du deinen Sensor integrieren?'
-                  options={[
-                    { name: "HTTP", value: "http" },
-                    { name: "TTN", value: "ttn" },
-                  ]}
+                  options={integrations.map(integration => ({
+                    name: integration.toUpperCase(),
+                    value: integration,
+                  }))}
                   errors={formatError(errors.connectionType?.message)}
                 />
               )}

--- a/src/components/SensorPageHeader/withData.tsx
+++ b/src/components/SensorPageHeader/withData.tsx
@@ -4,6 +4,7 @@ import { EditAddSensorModal } from "@components/EditAddSensorModal";
 import { SmallModalOverlay } from "@components/SmallModalOverlay";
 import { ParsedSensorType } from "@lib/hooks/usePublicSensors";
 import { useUserData } from "@lib/hooks/useUserData";
+import { IntegrationType } from "@lib/integrationsUtil";
 import { useRouter } from "next/router";
 import { FC, useState } from "react";
 import { SensorPageHeader } from ".";
@@ -77,7 +78,7 @@ export const SensorPageHeaderWithData: FC<SensorPageHeaderWithDataPropType> = ({
               ...mergedSensor,
               ...data,
               id: initialSensor.id,
-              ttnDeviceId: data.ttnDeviceId as "http" | "ttn",
+              ttnDeviceId: data.ttnDeviceId as IntegrationType,
             })
               .then(() => setShowEditSuccessAlert(true))
               .finally(() => {

--- a/src/lib/hooks/usePublicSensors/index.ts
+++ b/src/lib/hooks/usePublicSensors/index.ts
@@ -2,6 +2,7 @@ import { supabase } from "@auth/supabase";
 import useSWR from "swr";
 import { definitions } from "@common/types/supabase";
 import { DateValueType } from "@common/interfaces";
+import { IntegrationType } from "@lib/integrationsUtil";
 
 export const RECORDS_LIMIT = 500;
 
@@ -56,7 +57,7 @@ export interface ParsedSensorType {
   parsedRecords: DateValueType[];
   categoryId: number;
   categoryName: string;
-  connectionType: "http" | "ttn";
+  connectionType: IntegrationType;
   ttnDeviceId?: string;
   latitude: number;
   longitude: number;

--- a/src/lib/integrationsUtil/index.ts
+++ b/src/lib/integrationsUtil/index.ts
@@ -1,0 +1,3 @@
+export type IntegrationType = "http" | "ttn";
+
+export const integrations = ["http", "ttn"] as IntegrationType[];

--- a/src/lib/integrationsUtil/integrationsUtil.test.ts
+++ b/src/lib/integrationsUtil/integrationsUtil.test.ts
@@ -1,0 +1,7 @@
+import { integrations } from "./index";
+describe("integrationsUtil", () => {
+  test("should be an array of strings", () => {
+    expect(Array.isArray(integrations)).toBe(true);
+    expect(integrations.every(s => typeof s === "string")).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR extracts any reference to the integrations to an external file dedicated for this purpose. I didn't do a hook here as there is no particular advantage to using one here. I just use a file from which I export the constants.