### PR TITLE
fix(LineChart): Extended Y Scale to allow negative values

### DIFF
--- a/src/components/AreaPath/index.tsx
+++ b/src/components/AreaPath/index.tsx
@@ -30,8 +30,10 @@ export const AreaPath: FC<LineGraphType> = ({ width, height, data }) => {
     range: [0, width],
   });
 
+  const minVal = min(normalizedData, getY) || 0;
+  const maxVal = max(normalizedData, getY) || 0;
   const yScale = scaleLinear<number>({
-    domain: [min(normalizedData, getY) || 0, max(normalizedData, getY) || 0],
+    domain: [minVal > 0 ? 0 : minVal, maxVal < 0 ? 0 : maxVal],
     range: [height, 0],
   });
 

--- a/src/components/AreaPath/index.tsx
+++ b/src/components/AreaPath/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { extent, max } from "d3-array";
+import { extent, max, min } from "d3-array";
 import { curveLinear } from "@visx/curve";
 import { AreaClosed } from "@visx/shape";
 import { scaleLinear, scaleUtc } from "@visx/scale";
@@ -31,7 +31,7 @@ export const AreaPath: FC<LineGraphType> = ({ width, height, data }) => {
   });
 
   const yScale = scaleLinear<number>({
-    domain: [0, max(normalizedData, getY) as number],
+    domain: [min(normalizedData, getY) || 0, max(normalizedData, getY) || 0],
     range: [height, 0],
   });
 

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { bisector, extent, max } from "d3-array";
+import { bisector, extent, max, min } from "d3-array";
 import { Group } from "@visx/group";
 import { scaleLinear, scaleUtc } from "@visx/scale";
 import { AxisBottom, AxisLeft } from "@visx/axis";
@@ -69,7 +69,7 @@ export const LineChart = withTooltip<LineGraphType, DateValueType>(
     });
 
     const yScale = scaleLinear<number>({
-      domain: [0, (max(data, getY) as number) * 1.2],
+      domain: [min(data, getY) || 0, (max(data, getY) || 0) * 1.2],
       range: [graphHeight, 0],
     });
 

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -68,8 +68,10 @@ export const LineChart = withTooltip<LineGraphType, DateValueType>(
       range: [0, graphWidth],
     });
 
+    const minVal = min(data, getY) || 0;
+    const maxVal = (max(data, getY) || 0) * 1.2;
     const yScale = scaleLinear<number>({
-      domain: [min(data, getY) || 0, (max(data, getY) || 0) * 1.2],
+      domain: [minVal > 0 ? 0 : minVal, maxVal < 0 ? 0 : maxVal],
       range: [graphHeight, 0],
     });
 

--- a/src/components/LinePath/index.tsx
+++ b/src/components/LinePath/index.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { extent, max } from "d3-array";
+import { extent, max, min } from "d3-array";
 import { curveLinear } from "@visx/curve";
 import { LinePath as Path } from "@visx/shape";
 import { scaleLinear, scaleUtc } from "@visx/scale";
@@ -25,7 +25,7 @@ export const LinePath: FC<LineGraphType> = ({
   });
 
   const yScale = scaleLinear<number>({
-    domain: [0, (max(data, getY) as number) * 1.2],
+    domain: [min(data, getY) || 0, (max(data, getY) || 0) * 1.2],
     range: [height, 0],
   });
 

--- a/src/components/LinePath/index.tsx
+++ b/src/components/LinePath/index.tsx
@@ -24,8 +24,10 @@ export const LinePath: FC<LineGraphType> = ({
     range: [0, width],
   });
 
+  const minVal = min(data, getY) || 0;
+  const maxVal = (max(data, getY) || 0) * 1.2;
   const yScale = scaleLinear<number>({
-    domain: [min(data, getY) || 0, (max(data, getY) || 0) * 1.2],
+    domain: [minVal > 0 ? 0 : minVal, maxVal < 0 ? 0 : maxVal],
     range: [height, 0],
   });
 


### PR DESCRIPTION
This PR extends the `yScale` of the `LineChart`, `LinePath`, and `AreaChart` components to allow negative values to be displayed.