### PR TITLE
fix(DayPickerInput): Allow date input fields to enter date manually

### DIFF
--- a/src/components/DayPickerInput/DayPickerInput.test.tsx
+++ b/src/components/DayPickerInput/DayPickerInput.test.tsx
@@ -18,7 +18,7 @@ describe("DayPickerInput", () => {
   });
   test("should call onDayChange when input changes", () => {
     const initialValue = "01/01/2021";
-    const targetValue = new Date("12/24/2021");
+    const targetValue = new Date("01/12/2021");
     const onDayChange = jest.fn();
     render(
       <DayPickerInput
@@ -32,11 +32,7 @@ describe("DayPickerInput", () => {
     fireEvent.change(input, {
       target: { value: formatDate(targetValue) },
     });
-    expect(onDayChange).toHaveBeenCalledWith(
-      targetValue,
-      expect.anything(),
-      expect.anything()
-    );
+    expect(onDayChange).toHaveBeenCalledWith(targetValue);
   });
   test("should focus nextEl if defined after day click", () => {
     render(

--- a/src/components/DayPickerInput/index.tsx
+++ b/src/components/DayPickerInput/index.tsx
@@ -54,41 +54,45 @@ export const DayPickerInput: FC<DayPickerInputExtendedProps> = ({
   dayPickerProps,
   nextElSelector,
   ...props
-}) => (
-  <OriginalDayPickerInput
-    value={value}
-    format='DD/MM/YYYY'
-    placeholder='DD/MM/YYYY'
-    formatDate={formatDate}
-    parseDate={parseDate}
-    dayPickerProps={{
-      localeUtils: moment,
-      locale: "de",
-      numberOfMonths: 1,
-      classNames: {
-        ...dayPickerClassNames,
-        ...props.classNames,
-      },
-      onDayClick:
-        dayPickerProps?.onDayClick ||
-        (() => {
-          if (!nextElSelector) return;
-          const nextEl = document.querySelector(
-            nextElSelector
-          ) as HTMLInputElement;
-          if (!nextEl) return;
-          nextEl.focus();
-          nextEl.setSelectionRange(0, 0);
-        }),
-      ...dayPickerProps,
-    }}
-    onDayChange={onDayChange}
-    classNames={{
-      container: styles.inputContainer,
-      overlayWrapper: "",
-      overlay: "",
-    }}
-    inputProps={{ tabIndex }}
-    {...props}
-  />
-);
+}) => {
+  return (
+    <OriginalDayPickerInput
+      value={value}
+      format='DD/MM/YYYY'
+      placeholder='DD/MM/YYYY'
+      formatDate={formatDate}
+      parseDate={parseDate}
+      dayPickerProps={{
+        localeUtils: moment,
+        locale: "de",
+        numberOfMonths: 1,
+        classNames: {
+          ...dayPickerClassNames,
+          ...props.classNames,
+        },
+        onDayClick:
+          dayPickerProps?.onDayClick ||
+          (() => {
+            if (!nextElSelector) return;
+            const nextEl = document.querySelector(
+              nextElSelector
+            ) as HTMLInputElement;
+            if (!nextEl) return;
+            nextEl.focus();
+            nextEl.setSelectionRange(0, 0);
+          }),
+        ...dayPickerProps,
+      }}
+      onDayChange={selectedDay => {
+        typeof selectedDay !== "undefined" && onDayChange(selectedDay);
+      }}
+      classNames={{
+        container: styles.inputContainer,
+        overlayWrapper: "",
+        overlay: "",
+      }}
+      inputProps={{ tabIndex }}
+      {...props}
+    />
+  );
+};


### PR DESCRIPTION
This PR fixes the fact that date input fields wouldn't let dates be entered by typing, rather only by using the UI. This is now possible.