### PR TITLE
fix(STADTPULS-438): max rows line chart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ NEXT_PUBLIC_MAPBOX_TOKEN="pk.eyVn03jxiI5HunjhdGzyw6Hszvi2dEV3WoaluGih2IZkWOBJmc1
 NEXT_PUBLIC_WEB_URL="http://localhost:3000" # For production, use your production URL
 NEXT_PUBLIC_SUPABASE_URL="https://YOUR_SUPABASE_URL.supabase.co"
 NEXT_PUBLIC_SUPABASE_PUBLIC_KEY="eyJKhbGciOisJIUzI1Nd2iIsInR5cCsI6..."
+NEXT_PUBLIC_SUPABASE_MAX_ROWS=1000
 NEXT_PUBLIC_API_URL="https://my-token-api.com"
 NEXT_PUBLIC_MAPBOX_LABELS_TILESET_URL="mapbox://styles/mapbox/light-v10"
 NEXT_PUBLIC_MAPBOX_NO_LABELS_TILESET_URL="mapbox://styles/mapbox/light-v10"

--- a/pages/sensors/[id].tsx
+++ b/pages/sensors/[id].tsx
@@ -17,6 +17,8 @@ import { GetServerSideProps } from "next";
 import React, { FC, useCallback, useEffect, useState } from "react";
 import { SensorPageHeaderWithData } from "@components/SensorPageHeader/withData";
 import { definitions } from "@common/types/supabase";
+import { Alert } from "@components/Alert";
+import { MAX_RENDERABLE_VALUES as MAX_RENDERABLE_VALUES_LINE_CHART } from "@components/LinePath";
 
 const today = new Date();
 today.setHours(0, 0, 0, 0);
@@ -80,12 +82,14 @@ const SensorPage: FC<{
   const { count: recordsCount } = useSensorRecordsCount(sensor.id);
   const {
     records,
+    recordsCount: requestedRecordsCount,
     error: recordsFetchError,
     isLoading: recordsAreLoading,
   } = useSensorRecords({
     sensorId: sensor.id,
     startDateString: currentDatetimeRange.startDateTimeString,
     endDateString: currentDatetimeRange.endDateTimeString,
+    maxRows: MAX_RENDERABLE_VALUES_LINE_CHART,
   });
   const parsedAndSortedRecords = createDateValueArray(records);
 
@@ -125,7 +129,8 @@ const SensorPage: FC<{
                     id: "all",
                     title: "Alle Daten",
                     onClick: async () => {
-                      const allRecords = await getRecordsBySensorId(sensor.id);
+                      const { records: allRecords } =
+                        await getRecordsBySensorId(sensor.id);
                       downloadCSV(
                         createCSVStructure(allRecords),
                         `${moment.parseZone().format("YYYY-MM-DD")}-sensor-${
@@ -157,6 +162,26 @@ const SensorPage: FC<{
               </DropdownMenu>
             </div>
           </div>
+          {requestedRecordsCount &&
+            requestedRecordsCount > MAX_RENDERABLE_VALUES_LINE_CHART && (
+              <Alert
+                type='warning'
+                title='Achtung'
+                message={
+                  <>
+                    Das Diagramm kann maximal{" "}
+                    <mark className='px-1 py-0.5 font-mono font-bold bg-warning bg-opacity-50'>
+                      {MAX_RENDERABLE_VALUES_LINE_CHART}
+                    </mark>{" "}
+                    Datenpunkte darstellen. Im gewählten Zeitraum befinden sich{" "}
+                    <mark className='px-1 py-0.5 font-mono font-bold bg-warning bg-opacity-50'>
+                      {requestedRecordsCount}
+                    </mark>{" "}
+                    Datenpunkte. <b>Die ältesten werden nicht dargestellt.</b>
+                  </>
+                }
+              />
+            )}
           <div
             className={[
               "pt-4 pb-8 mt-6 flex space-between flex-wrap gap-6",

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import moment from "moment";
+import { Button } from "@components/Button";
 
 interface DataTableRowType {
   id: number;
@@ -126,9 +127,11 @@ export const DataTable: React.FC<DataTableType> = ({ data }) => {
         </tbody>
       </table>
       {data && data.length > numberOfRecordsToDisplay && (
-        <button className='mt-3' onClick={handleLoadMore}>
-          Mehr anzeigen
-        </button>
+        <div className='my-3 flex items-center justify-center'>
+          <Button variant='secondary' onClick={handleLoadMore}>
+            Mehr anzeigen
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/src/components/LinePath/index.tsx
+++ b/src/components/LinePath/index.tsx
@@ -9,6 +9,8 @@ import colors from "../../style/colors";
 const getX = (d: DateValueType): Date => new Date(d.date);
 const getY = (d: DateValueType): number => d.value;
 
+export const MAX_RENDERABLE_VALUES = 3000;
+
 export const LinePath: FC<LineGraphType> = ({
   width,
   height,

--- a/src/lib/hooks/useSensorRecords/index.ts
+++ b/src/lib/hooks/useSensorRecords/index.ts
@@ -1,61 +1,71 @@
 import { definitions } from "@common/types/supabase";
-import { getRecordsBySensorId } from "@lib/requests/getRecordsBySensorId";
+import {
+  getRecordsBySensorId,
+  GetRecordsResponseType,
+} from "@lib/requests/getRecordsBySensorId";
 import useSWR from "swr";
 
 interface useSensorRecordsParamsType {
   sensorId: number | undefined;
   startDateString?: string;
   endDateString?: string;
+  maxRows?: number;
 }
 
 interface useSensorRecordsReturnType {
   isLoading: boolean;
   records: definitions["records"][];
+  recordsCount: number | null;
   error: Error | null;
 }
 
 type fetchSensorRecordsSignature = (
   params: useSensorRecordsParamsType
-) => Promise<definitions["records"][]>;
+) => Promise<GetRecordsResponseType>;
 
 const fetchSensorRecords: fetchSensorRecordsSignature = async ({
   sensorId,
   startDateString,
   endDateString,
+  maxRows,
 }) => {
-  if (!sensorId) return [];
+  if (!sensorId) return { records: [], count: null };
 
-  const records = await getRecordsBySensorId(sensorId, {
+  const { records, count } = await getRecordsBySensorId(sensorId, {
     startDate: startDateString,
     endDate: endDateString,
+    maxRows: maxRows,
   });
-  return records;
+
+  return { records, count };
 };
 
 export const useSensorRecords = ({
   sensorId,
   startDateString,
   endDateString,
+  maxRows,
 }: useSensorRecordsParamsType): useSensorRecordsReturnType => {
   const params = [
     `sensor-${sensorId || "no"}-records`,
     sensorId,
     startDateString,
     endDateString,
+    maxRows,
   ];
-  const { data: records, error } = useSWR<definitions["records"][], Error>(
-    params,
-    () =>
-      fetchSensorRecords({
-        sensorId,
-        startDateString,
-        endDateString,
-      })
+  const { data, error } = useSWR<GetRecordsResponseType, Error>(params, () =>
+    fetchSensorRecords({
+      sensorId,
+      startDateString,
+      endDateString,
+      maxRows,
+    })
   );
 
   return {
-    isLoading: records === undefined,
-    records: records || ([] as definitions["records"][]),
+    isLoading: data?.records === undefined,
+    records: data?.records || ([] as definitions["records"][]),
+    recordsCount: data?.count || null,
     error: error || null,
   };
 };

--- a/src/lib/requests/getRecordsBySensorId/getRecordsBySensorId.test.ts
+++ b/src/lib/requests/getRecordsBySensorId/getRecordsBySensorId.test.ts
@@ -17,10 +17,7 @@ describe("utility function getRecordsBySensorId", () => {
       })
     );
     server.listen();
-    const records = await getRecordsBySensorId(exampleSensor.id);
-
-    expect.assertions(2);
-    expect(Array.isArray(records)).toBe(true);
+    const { records } = await getRecordsBySensorId(exampleSensor.id);
     const allRecordsBelongToProvidedDevice = records.every(record => {
       return record.sensor_id === exampleSensor.id;
     });
@@ -54,7 +51,7 @@ describe("utility function getRecordsBySensorId", () => {
     );
     server.listen();
 
-    const records = await getRecordsBySensorId(exampleSensor.id, {
+    const { records } = await getRecordsBySensorId(exampleSensor.id, {
       startDate: testStartDate,
       endDate: testEndDate,
     });
@@ -94,7 +91,7 @@ describe("utility function getRecordsBySensorId", () => {
     );
     server.listen();
 
-    const records = await getRecordsBySensorId(exampleSensor.id, {
+    const { records } = await getRecordsBySensorId(exampleSensor.id, {
       startDate: testStartDate,
     });
 
@@ -133,7 +130,7 @@ describe("utility function getRecordsBySensorId", () => {
     );
     server.listen();
 
-    const records = await getRecordsBySensorId(exampleSensor.id, {
+    const { records } = await getRecordsBySensorId(exampleSensor.id, {
       endDate: testEndDate,
     });
 
@@ -161,7 +158,7 @@ describe("utility function getRecordsBySensorId", () => {
     );
     server.listen();
 
-    const records = await getRecordsBySensorId(exampleSensor.id, {});
+    const { records } = await getRecordsBySensorId(exampleSensor.id, {});
 
     expect.assertions(2);
     expect(Array.isArray(records)).toBe(true);

--- a/src/lib/requests/getRecordsBySensorId/index.ts
+++ b/src/lib/requests/getRecordsBySensorId/index.ts
@@ -4,75 +4,109 @@ import { definitions } from "@common/types/supabase";
 export interface GetRecordsOptionsType {
   startDate?: string;
   endDate?: string;
+  maxRows?: number;
+}
+
+export interface GetRecordsResponseType {
+  records: definitions["records"][];
+  count: number | null;
 }
 
 export const getRecordsBySensorId = async (
   sensorId: number,
   options?: GetRecordsOptionsType
-): Promise<definitions["records"][]> => {
+): Promise<GetRecordsResponseType> => {
+  const MAX_ROWS =
+    options?.maxRows ||
+    Number.parseInt(process.env.NEXT_PUBLIC_SUPABASE_MAX_ROWS as string, 10);
+
   if (options) {
     switch (true) {
       case !!(options && options.startDate && options.endDate): {
-        const { data: records, error } = await supabase
+        const {
+          data: records,
+          error,
+          count,
+        } = await supabase
           .from<definitions["records"]>("records")
-          .select("*")
+          .select("*", { count: "exact", head: false })
+          .limit(MAX_ROWS)
           .eq("sensor_id", sensorId)
           .gte("recorded_at", options.startDate)
           .lte("recorded_at", options.endDate)
           .order("recorded_at", { ascending: false });
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
-
-        return records;
+        return { records, count };
       }
 
       case !!(options && options.startDate && !options.endDate): {
-        const { data: records, error } = await supabase
+        const {
+          data: records,
+          error,
+          count,
+        } = await supabase
           .from<definitions["records"]>("records")
-          .select("*")
+          .select("*", { count: "exact" })
+          .limit(MAX_ROWS)
           .eq("sensor_id", sensorId)
           .gte("recorded_at", options.startDate)
           .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
-        return records;
+        return { records, count };
       }
 
       case !!(options && !options.startDate && options.endDate): {
-        const { data: records, error } = await supabase
+        const {
+          data: records,
+          error,
+          count,
+        } = await supabase
           .from<definitions["records"]>("records")
-          .select("*")
+          .select("*", { count: "exact" })
+          .limit(MAX_ROWS)
           .eq("sensor_id", sensorId)
           .lte("recorded_at", options.endDate)
           .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found for this time range`);
-        return records;
+        return { records, count };
       }
 
       default: {
-        const { data: records, error } = await supabase
+        const {
+          data: records,
+          error,
+          count,
+        } = await supabase
           .from<definitions["records"]>("records")
-          .select("*")
+          .select("*", { count: "exact" })
+          .limit(MAX_ROWS)
           .eq("sensor_id", sensorId)
           .order("recorded_at", { ascending: false });
 
         if (error) throw error;
         if (!records) throw new Error(`No records found`);
-        return records;
+        return { records, count };
       }
     }
   } else {
-    const { data: records, error } = await supabase
+    const {
+      data: records,
+      error,
+      count,
+    } = await supabase
       .from<definitions["records"]>("records")
-      .select("*")
+      .select("*", { count: "exact" })
+      .limit(MAX_ROWS)
       .eq("sensor_id", sensorId)
       .order("recorded_at", { ascending: false });
 
     if (error) throw error;
     if (!records) throw new Error(`No records found for sensor ID ${sensorId}`);
-    return records;
+    return { records, count };
   }
 };


### PR DESCRIPTION
Before merge:
- [x] update Supabase max rows limit in production instance
---
This PR updates the line chart so that it can display more values. We found that **about 3000 values are the maximum** for our current charting library (visx). A `canvas`-based alternative should be explored in the future to increase the number of renderable values.

If the selected timespan has more values than the defined 3000, we show an alert informing about the limitation of the line chart.

![Screenshot 2021-11-03 at 17 40 30](https://user-images.githubusercontent.com/15640196/140104048-595d0142-0225-4a74-a2f1-9687afd3e988.png)

~~Note that it is still possible to select _Alle_ even for requests that exceed 3000 values. This is because we don't want to limit accessing more than 3000 values for the download button. The button should not be limited by the rendering limits of the line chart. The alert message is shown upon selecting an _Alle_ that exceeds 3000.~~

This PR also introduces a new environment variable `NEXT_PUBLIC_SUPABASE_MAX_ROWS` that can be used for ensuring we are always in sync with our settings in Supabase. Please refer to the `.env` values in the shared 1Password vault.


