### PR TITLE
refactor: build the homepage with ISR

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,16 +11,16 @@ import {
   getLandingStats,
   LandingStatsReturnType,
 } from "@lib/requests/getLandingStats";
-import { GetServerSideProps } from "next";
+import { GetStaticProps } from "next";
 import { FC, useState } from "react";
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   try {
     const [stats, curatedSensors] = await Promise.all([
       getLandingStats(),
       getCuratedSensors(),
     ]);
-    return { props: { stats, curatedSensors } };
+    return { props: { stats, curatedSensors }, revalidate: 60 };
   } catch (error) {
     console.log(error);
     return { notFound: true };


### PR DESCRIPTION
This PR enables Next's [Incremental Static Regeneration (ISR)](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration) for the homepage. This means:

- The homepage is generated at build-time instead of rendered by the server on every hit
- **Load times for the homepage are reduced**: In my tests the staging URL loads the DOM in 100 - 300 ms, while stadtpuls.com needs about 1 s
- The only "dynamic" elements on the homepage are regenerated every 60 s at most (see ISR docs for details). This is relevant mainly for the stats section. I simulated adding and deleting sensors and the ISR promise of regeneration works as expected.

Note that the effect of ISR [is not visible in development](https://nextjs.org/docs/basic-features/data-fetching#runs-on-every-request-in-development).