### PR TITLE
fix: make hero buttons clickable on small screens

### DIFF
--- a/src/components/LandingHero/__snapshots__/LandingHero.stories.storyshot
+++ b/src/components/LandingHero/__snapshots__/LandingHero.stories.storyshot
@@ -8,7 +8,9 @@ exports[`Storyshots Promotional/LandingHero Default 1`] = `
     <div
       className="relative z-10 container mx-auto max-w-8xl grid lg:grid-cols-2 gap-16 px-6 md:px-8 pt-16 sm:pt-24 lg:pt-40 pb-96 md:pt-24 lg:pb-40 text-white"
     >
-      <div>
+      <div
+        className="z-20 lg:z-auto"
+      >
         <h1
           className="animate-slide-in text-xl sm:text-2xl md:text-3xl text-green font-headline font-bold mt-6 mb-1"
         >

--- a/src/components/LandingHero/index.tsx
+++ b/src/components/LandingHero/index.tsx
@@ -17,7 +17,7 @@ export const LandingHero: FC = () => (
           "text-white",
         ].join(" ")}
       >
-        <div>
+        <div className='z-20 lg:z-auto'>
           <h1
             className={[
               "animate-slide-in",


### PR DESCRIPTION
This PR fixes the stacking of the hero section. On small screens (below Tailwind's `lg`) the hero image was positioned not next to but under the intro text. However, because the image has a `z-index` of 10, the buttons of the intro text were covered by the image and therefore not clickable. This PR lifts the intro text's `z-index` to 20 on small screens.