### PR TITLE
feat(STADTPULS-471): order sensors by creation date (newest first)

### DIFF
--- a/src/lib/requests/getPublicSensors/index.ts
+++ b/src/lib/requests/getPublicSensors/index.ts
@@ -86,7 +86,6 @@ export const getPublicSensors = async (
 
     if (error) throw error;
     if (!data) return [];
-    console.log(data[0].records);
     const sensors = data?.map(mapPublicSensor);
 
     return sensors;
@@ -106,7 +105,6 @@ export const getPublicSensors = async (
 
     if (error) throw error;
     if (!data) return [];
-    console.log(data[0].records);
     const sensors = data?.map(mapPublicSensor);
 
     return sensors;

--- a/src/lib/requests/getPublicSensors/index.ts
+++ b/src/lib/requests/getPublicSensors/index.ts
@@ -74,6 +74,13 @@ export const getPublicSensors = async (
       .from<SensorQueryResponseType>("sensors")
       .select(sensorQueryString)
       .order("created_at", { ascending: false })
+      // FIXME: recorded_at is not recognized altought it is inherited from the definitions
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .order("recorded_at", {
+        foreignTable: "records",
+        ascending: false,
+      })
       .range(options.rangeStart, options.rangeEnd)
       .limit(RECORDS_LIMIT, { foreignTable: "records" });
 
@@ -88,6 +95,13 @@ export const getPublicSensors = async (
       .from<SensorQueryResponseType>("sensors")
       .select(sensorQueryString)
       .order("created_at", { ascending: false })
+      // FIXME: recorded_at is not recognized altought it is inherited from the definitions
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .order("recorded_at", {
+        foreignTable: "records",
+        ascending: false,
+      })
       .limit(RECORDS_LIMIT, { foreignTable: "records" });
 
     if (error) throw error;

--- a/src/lib/requests/getPublicSensors/index.ts
+++ b/src/lib/requests/getPublicSensors/index.ts
@@ -73,18 +73,13 @@ export const getPublicSensors = async (
     const { data, error } = await supabase
       .from<SensorQueryResponseType>("sensors")
       .select(sensorQueryString)
-      // FIXME: created_at is not recognized altought it is inherited from the definitions
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      .order("recorded_at", {
-        foreignTable: "records",
-        ascending: false,
-      })
+      .order("created_at", { ascending: false })
       .range(options.rangeStart, options.rangeEnd)
       .limit(RECORDS_LIMIT, { foreignTable: "records" });
 
     if (error) throw error;
     if (!data) return [];
+    console.log(data[0].records);
     const sensors = data?.map(mapPublicSensor);
 
     return sensors;
@@ -92,17 +87,12 @@ export const getPublicSensors = async (
     const { data, error } = await supabase
       .from<SensorQueryResponseType>("sensors")
       .select(sensorQueryString)
-      // FIXME: created_at is not recognized altought it is inherited from the definitions
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      .order("recorded_at", {
-        foreignTable: "records",
-        ascending: false,
-      })
+      .order("created_at", { ascending: false })
       .limit(RECORDS_LIMIT, { foreignTable: "records" });
 
     if (error) throw error;
     if (!data) return [];
+    console.log(data[0].records);
     const sensors = data?.map(mapPublicSensor);
 
     return sensors;


### PR DESCRIPTION
This PR orders the sensors returned from `getPublicSensors` by creation date (newest sensors first). This makes the most recently added sensors show up first on `/sensors`.