### PR TITLE
feat(STADTPULS-501): less scary line chart alert

### DIFF
--- a/pages/sensors/[id].tsx
+++ b/pages/sensors/[id].tsx
@@ -164,19 +164,17 @@ const SensorPage: FC<{
           {requestedRecordsCount &&
             requestedRecordsCount > MAX_RENDERABLE_VALUES_LINE_CHART && (
               <Alert
-                type='warning'
-                title='Achtung'
                 message={
                   <>
                     Das Diagramm kann maximal{" "}
-                    <mark className='px-1 py-0.5 font-mono font-bold bg-warning bg-opacity-50'>
+                    <mark className='px-1 py-0.5 font-mono font-bold bg-gray-100 text-blue'>
                       {MAX_RENDERABLE_VALUES_LINE_CHART}
                     </mark>{" "}
                     Datenpunkte darstellen. Im gewählten Zeitraum befinden sich{" "}
-                    <mark className='px-1 py-0.5 font-mono font-bold bg-warning bg-opacity-50'>
+                    <mark className='px-1 py-0.5 font-mono font-bold bg-gray-100 text-blue'>
                       {requestedRecordsCount}
                     </mark>{" "}
-                    Datenpunkte. <b>Die ältesten werden nicht dargestellt.</b>
+                    Datenpunkte. Die ältesten werden nicht dargestellt.
                   </>
                 }
               />

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -4,12 +4,12 @@ import { Alert } from ".";
 describe("Alert component", () => {
   it("should render an info alert without type", () => {
     render(<Alert message='Info' />);
-    const alert = document.querySelector(".border-blue.bg-blue");
+    const alert = document.querySelector(".border-blue.bg-gray-300");
     expect(alert).toBeInTheDocument();
   });
   it("should render an info alert with info type", () => {
     render(<Alert type='info' message='Info' />);
-    const alert = document.querySelector(".border-blue.bg-blue");
+    const alert = document.querySelector(".border-blue.bg-gray-300");
     expect(alert).toBeInTheDocument();
   });
   it("should render an error alert with error type", () => {

--- a/src/components/Alert/__snapshots__/Alert.stories.storyshot
+++ b/src/components/Alert/__snapshots__/Alert.stories.storyshot
@@ -40,7 +40,7 @@ exports[`Storyshots UI Elements/Alert Error 1`] = `
 
 exports[`Storyshots UI Elements/Alert Info 1`] = `
 <div
-  className="border px-5 py-3 bg-opacity-5 flex gap-x-5 pr-8 relative flex-wrap border-blue bg-blue"
+  className="border px-5 py-3 bg-opacity-5 flex gap-x-5 pr-8 relative flex-wrap border-blue bg-gray-300"
   role="alert"
 >
   <h4
@@ -78,7 +78,7 @@ exports[`Storyshots UI Elements/Alert Info 1`] = `
 
 exports[`Storyshots UI Elements/Alert No Title 1`] = `
 <div
-  className="border px-5 py-3 bg-opacity-5 flex gap-x-5 pr-8 relative flex-wrap border-blue bg-blue"
+  className="border px-5 py-3 bg-opacity-5 flex gap-x-5 pr-8 relative flex-wrap border-blue bg-gray-300"
   role="alert"
 >
   <p>

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -11,7 +11,7 @@ const getStylesByType = (type: AlertPropType["type"]): string =>
   [
     "border px-5 py-3 bg-opacity-5",
     "flex gap-x-5 pr-8 relative flex-wrap",
-    type === "info" && "border-blue bg-blue",
+    type === "info" && "border-blue bg-gray-300",
     type === "error" && "border-error bg-error",
     type === "success" && "border-green bg-green",
     type === "warning" && "border-warning bg-warning",


### PR DESCRIPTION
This PR updates the informational Alert component to have a light gray background and updates the content of the alert message when the line chart is asked to display more than 3000 records.