### PR TITLE
feat(STADTPULS-488): sort and paginate accounts overview

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     "activityBarBadge.foreground": "#15202b",
     "statusBar.background": "#100C53",
     "statusBar.foreground": "#8330FF",
-    "statusBarItem.hoverBackground": "#8330FF",
+    "statusBarItem.hoverBackground": "#46ECA1",
     "titleBar.activeBackground": "#100C53",
     "titleBar.activeForeground": "#46ECA1",
     "titleBar.inactiveBackground": "#100C53",

--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -1,21 +1,30 @@
 import { FC } from "react";
 import { AccountsGrid } from "@components/AccountsGrid";
 import { GetServerSideProps } from "next";
+import { ParsedAccountType } from "@lib/hooks/usePublicAccounts";
 import {
-  getPublicAccounts,
-  ParsedAccountType,
-  usePublicAccounts,
-} from "@lib/hooks/usePublicAccounts";
-import { Alert } from "@components/Alert";
+  getRangeByPageNumber,
+  MAX_SENSORS_PER_PAGE as MAX_ACCOUNTS_PER_PAGE,
+} from "../sensors";
+import { Pagination } from "@components/Pagination";
+import router from "next/router";
+import { getLandingStats } from "@lib/requests/getLandingStats";
+import classNames from "classnames";
+import { getPublicAccounts } from "@lib/requests/getPublicAccounts";
 
 interface AccountsOverviewPropType {
-  initialAccounts: ParsedAccountType[];
+  accounts: ParsedAccountType[];
+  accountsCount: number;
+  page: number;
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const page = Array.isArray(query.page) ? 1 : Number.parseInt(query.page) || 1;
+  const [rangeStart, rangeEnd] = getRangeByPageNumber(page);
   try {
-    const initialAccounts = await getPublicAccounts();
-    return { props: { initialAccounts } };
+    const accounts = await getPublicAccounts({ rangeStart, rangeEnd });
+    const { usersCount: accountsCount } = await getLandingStats();
+    return { props: { accounts, accountsCount, page } };
   } catch (error) {
     console.error("Error when fetching accounts:");
     console.error(error);
@@ -23,29 +32,35 @@ export const getServerSideProps: GetServerSideProps = async () => {
   }
 };
 
+const handlePageChange = ({
+  selectedPage,
+  pageCount,
+}: {
+  selectedPage: number;
+  pageCount: number;
+}): void => {
+  const path = router.pathname;
+  const query =
+    selectedPage === 1 || selectedPage > pageCount
+      ? ""
+      : `page=${selectedPage}`;
+
+  void router.push({
+    pathname: path,
+    query: query,
+  });
+};
+
 const AccountsOverview: FC<AccountsOverviewPropType> = ({
-  initialAccounts,
+  accounts,
+  accountsCount,
+  page,
 }) => {
-  const { accounts, error } = usePublicAccounts(initialAccounts);
-  if (error)
-    return (
-      <div className='container mx-auto max-w-8xl py-24 px-4'>
-        <Alert
-          title='Fehler'
-          type='error'
-          message={
-            <>
-              {console.log(error)}
-              Es ist ein Fehler beim Laden der Accounts aufgetreten.
-              <code className='ml-4 px-2 py-1 font-mono bg-error bg-opacity-20'>
-                {error.message}
-              </code>
-            </>
-          }
-        />
-      </div>
-    );
-  if (accounts.length === 0)
+  const pageCount = Math.ceil(accountsCount / MAX_ACCOUNTS_PER_PAGE);
+  const pageIsWithinPageCount = page <= pageCount;
+  const pageToRender = pageIsWithinPageCount ? page : 1;
+
+  if ((!accounts || accounts.length === 0) && pageIsWithinPageCount)
     return (
       <div className='container mx-auto max-w-8xl py-24 px-4'>
         <h1 className='flex justify-center mt-8'>Keine Accounts vorhanden</h1>
@@ -53,16 +68,36 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
     );
   return (
     <div className='container mx-auto max-w-8xl py-24 px-4'>
-      <h1
-        className={[
-          "font-bold text-xl sm:text-2xl md:text-3xl font-headline",
+      <div
+        className={classNames(
           "sm:mt-1 md:mt-2",
           "mb-4 sm:mb-5 md:mb-6",
-        ].join(" ")}
+          "flex place-content-between"
+        )}
       >
-        Alle Accounts
-      </h1>
+        <h1
+          className={[
+            "font-bold text-xl sm:text-2xl md:text-3xl font-headline",
+          ].join(" ")}
+        >
+          Alle Accounts
+        </h1>
+        <h2 className='text-gray-600 mt-0 md:mt-2'>
+          Seite {page} von {pageCount}
+        </h2>
+      </div>
       <AccountsGrid accounts={accounts} />
+      <div className='mt-12 flex justify-center'>
+        <Pagination
+          pageCount={pageCount}
+          numberOfDisplayedPages={5}
+          marginPagesDisplayed={1}
+          currentPage={pageToRender}
+          onPageChange={({ selected: selectedIndex }) => {
+            handlePageChange({ selectedPage: selectedIndex + 1, pageCount });
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -27,6 +27,9 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
   initialAccounts,
 }) => {
   const { accounts, error } = usePublicAccounts(initialAccounts);
+  const accountsWithAtLeastOneSensor = accounts.filter(
+    account => account.sensors.length > 0
+  );
   if (error)
     return (
       <div className='container mx-auto max-w-8xl py-24 px-4'>
@@ -45,7 +48,7 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
         />
       </div>
     );
-  if (accounts.length === 0)
+  if (accountsWithAtLeastOneSensor.length === 0)
     return (
       <div className='container mx-auto max-w-8xl py-24 px-4'>
         <h1 className='flex justify-center mt-8'>Keine Accounts vorhanden</h1>
@@ -62,7 +65,11 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
       >
         Alle Accounts
       </h1>
-      <AccountsGrid accounts={accounts} />
+      <AccountsGrid accounts={accountsWithAtLeastOneSensor} />
+      <p className='mt-20 text-sm text-gray-500 mx-auto text-center'>
+        Es werden nur Accounts gezeigt, die über mindestens einen Sensor
+        verfügen.
+      </p>
     </div>
   );
 };

--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -27,9 +27,6 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
   initialAccounts,
 }) => {
   const { accounts, error } = usePublicAccounts(initialAccounts);
-  const accountsWithAtLeastOneSensor = accounts.filter(
-    account => account.sensors.length > 0
-  );
   if (error)
     return (
       <div className='container mx-auto max-w-8xl py-24 px-4'>
@@ -48,7 +45,7 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
         />
       </div>
     );
-  if (accountsWithAtLeastOneSensor.length === 0)
+  if (accounts.length === 0)
     return (
       <div className='container mx-auto max-w-8xl py-24 px-4'>
         <h1 className='flex justify-center mt-8'>Keine Accounts vorhanden</h1>
@@ -65,11 +62,7 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
       >
         Alle Accounts
       </h1>
-      <AccountsGrid accounts={accountsWithAtLeastOneSensor} />
-      <p className='mt-20 text-sm text-gray-500 mx-auto text-center'>
-        Es werden nur Accounts gezeigt, die über mindestens einen Sensor
-        verfügen.
-      </p>
+      <AccountsGrid accounts={accounts} />
     </div>
   );
 };

--- a/pages/sensors/index.tsx
+++ b/pages/sensors/index.tsx
@@ -14,9 +14,9 @@ interface SensorsOverviewPropType {
   page: number;
 }
 
-const MAX_SENSORS_PER_PAGE = 15;
+export const MAX_SENSORS_PER_PAGE = 15;
 
-const getRangeByPageNumber = (page: number): [number, number] => {
+export const getRangeByPageNumber = (page: number): [number, number] => {
   const rangeStart = (page - 1) * MAX_SENSORS_PER_PAGE;
   const rangeEnd = rangeStart + MAX_SENSORS_PER_PAGE - 1;
   return [rangeStart, rangeEnd];

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,8 +1,6 @@
-import {
-  getPublicAccounts,
-  ParsedAccountType,
-} from "@lib/hooks/usePublicAccounts";
+import { ParsedAccountType } from "@lib/hooks/usePublicAccounts";
 import { ParsedSensorType } from "@lib/hooks/usePublicSensors";
+import { getPublicAccounts } from "@lib/requests/getPublicAccounts";
 import { getPublicSensors } from "@lib/requests/getPublicSensors";
 import { NextPage, NextApiResponse } from "next";
 import { Component } from "react";

--- a/src/components/AccountsGrid/AccountsGrid.test.tsx
+++ b/src/components/AccountsGrid/AccountsGrid.test.tsx
@@ -1,6 +1,6 @@
 import { screen, render } from "@testing-library/react";
 import { AccountsGrid } from ".";
-import { getPublicAccounts } from "@lib/hooks/usePublicAccounts";
+import { getPublicAccounts } from "@lib/requests/getPublicAccounts";
 describe("AccountsGrid component", () => {
   it("should render the first sensor", async (): Promise<void> => {
     const accounts = await getPublicAccounts();

--- a/src/lib/hooks/usePublicAccounts/index.ts
+++ b/src/lib/hooks/usePublicAccounts/index.ts
@@ -67,8 +67,8 @@ export const getPublicAccounts = async (): Promise<ParsedAccountType[]> => {
   const { data, error } = await supabase
     .from<AccountQueryResponseType>("user_profiles")
     .select(accountQueryString)
-    .order("created_at")
-    // FIXME: created_at is not recognized altought it is inherited from the definitions
+    .order("name")
+    // FIXME: recorded_at is not recognized altought it is inherited from the definitions
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     .order("recorded_at", {

--- a/src/lib/requests/getPublicAccounts/getPublicAccounts.test.ts
+++ b/src/lib/requests/getPublicAccounts/getPublicAccounts.test.ts
@@ -1,0 +1,100 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { getPublicAccounts } from ".";
+import { createSupabaseUrl } from "../createSupabaseUrl";
+import { publicAccounts as exampleAccounts } from "@mocks/supabaseData/accounts";
+import { errors } from "../getPublicSensors";
+import { AccountQueryResponseType } from "@lib/hooks/usePublicAccounts";
+
+const getIndexesFromRange = (
+  rangeStart: number,
+  rangeEnd: number
+): { fromIndex: number; toIndex: number } => {
+  return {
+    fromIndex: rangeStart - 1,
+    toIndex: rangeEnd - 1,
+  };
+};
+
+describe("utility function getPublicAccounts", () => {
+  it("returns all public accounts", async (): Promise<void> => {
+    const server = setupServer(
+      rest.get(createSupabaseUrl(`/user_profiles`), (_req, res, ctx) => {
+        return res(ctx.status(200, "Mocked status"), ctx.json(exampleAccounts));
+      })
+    );
+    server.listen();
+    const fetchedAccounts = await getPublicAccounts();
+    expect(fetchedAccounts.length).toEqual(exampleAccounts.length);
+    server.resetHandlers();
+    server.close();
+  });
+
+  it("returns a limited amount of accounts if range is provided", async (): Promise<void> => {
+    const rangeStart = 0;
+    const rangeEnd = 3;
+    let filteredAccounts: AccountQueryResponseType[] = [];
+
+    const server = setupServer(
+      rest.get(createSupabaseUrl(`/user_profiles`), (req, res, ctx) => {
+        const { fromIndex, toIndex } = getIndexesFromRange(
+          rangeStart,
+          rangeEnd
+        );
+
+        const limit = req.url.searchParams.get("limit");
+        const offset = req.url.searchParams.get("offset");
+
+        filteredAccounts = exampleAccounts.filter((_, index) => {
+          return index >= fromIndex && index <= toIndex;
+        });
+
+        return res(
+          ctx.status(200, "Mocked status"),
+          ctx.json(limit && offset ? filteredAccounts : exampleAccounts)
+        );
+      })
+    );
+    server.listen();
+
+    const fetchedAccounts = await getPublicAccounts({ rangeStart, rangeEnd });
+    expect(fetchedAccounts.length).toEqual(filteredAccounts.length);
+
+    const expectedAccountIds = filteredAccounts.map(sensor => sensor.id);
+
+    const allReturnedIdsAreIncludedInExpectedIds = fetchedAccounts.every(
+      account => expectedAccountIds.includes(account.id)
+    );
+    expect(allReturnedIdsAreIncludedInExpectedIds).toBe(true);
+
+    server.resetHandlers();
+    server.close();
+  });
+
+  it("errors when rangeEnd is greater than rangeStart", async (): Promise<void> => {
+    const rangeStart = 3;
+    const rangeEnd = 2;
+
+    // No mock server needed because we're throwing early
+
+    try {
+      await getPublicAccounts({ rangeStart, rangeEnd });
+    } catch (error: unknown) {
+      expect((error as Error).message).toEqual(
+        errors.rangeEndGreaterThanRangeStart
+      );
+    }
+  });
+
+  it("errors when rangeEnd is provided without rangeStart", async (): Promise<void> => {
+    const rangeEnd = 3;
+
+    // No mock server needed because we're throwing early
+
+    try {
+      await getPublicAccounts({ rangeEnd });
+    } catch (error: unknown) {
+      expect((error as Error).message).toEqual(errors.onlyOneRangeValue);
+    }
+  });
+});

--- a/src/lib/requests/getPublicAccounts/index.ts
+++ b/src/lib/requests/getPublicAccounts/index.ts
@@ -1,0 +1,80 @@
+import { supabase } from "@auth/supabase";
+import {
+  ParsedAccountType,
+  AccountQueryResponseType,
+  accountQueryString,
+  mapPublicAccount,
+} from "@lib/hooks/usePublicAccounts";
+import { errors, RECORDS_LIMIT } from "../getPublicSensors";
+
+export interface GetAccountsOptionsType {
+  rangeStart?: number;
+  rangeEnd?: number;
+}
+
+export const getPublicAccounts = async (
+  options?: GetAccountsOptionsType
+): Promise<ParsedAccountType[]> => {
+  if (
+    options &&
+    typeof options.rangeStart !== "undefined" &&
+    typeof options.rangeEnd !== "undefined" &&
+    options.rangeEnd <= options.rangeStart
+  )
+    throw new Error(errors.rangeEndGreaterThanRangeStart);
+
+  if (
+    (options &&
+      typeof options.rangeStart !== "undefined" &&
+      typeof options.rangeEnd === "undefined") ||
+    (options &&
+      typeof options.rangeStart === "undefined" &&
+      typeof options.rangeEnd !== "undefined")
+  )
+    throw new Error(errors.onlyOneRangeValue);
+
+  if (
+    options &&
+    (options.rangeStart || options.rangeStart === 0) &&
+    options.rangeEnd
+  ) {
+    const { data, error } = await supabase
+      .from<AccountQueryResponseType>("user_profiles")
+      .select(accountQueryString)
+      .order("name")
+      // FIXME: recorded_at is not recognized altought it is inherited from the definitions
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .order("recorded_at", {
+        foreignTable: "sensors.records",
+        ascending: false,
+      })
+      .range(options.rangeStart, options.rangeEnd)
+      .limit(RECORDS_LIMIT, { foreignTable: "sensors.records" });
+
+    if (error) throw error;
+    if (!data) return [];
+    const accounts = data.map(mapPublicAccount);
+
+    return accounts;
+  } else {
+    const { data, error } = await supabase
+      .from<AccountQueryResponseType>("user_profiles")
+      .select(accountQueryString)
+      .order("name")
+      // FIXME: recorded_at is not recognized altought it is inherited from the definitions
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      .order("recorded_at", {
+        foreignTable: "sensors.records",
+        ascending: false,
+      })
+      .limit(RECORDS_LIMIT, { foreignTable: "sensors.records" });
+
+    if (error) throw error;
+    if (!data) return [];
+    const accounts = data.map(mapPublicAccount);
+
+    return accounts;
+  }
+};


### PR DESCRIPTION
This PR turned out a a bit differently than originally planned. STADTPULS-489 is outdated, instead we handle the accounts overview as discussed in the comments below.