### PR TITLE
refactor(STADTPULS-475): Make default time filter be "max"

### DIFF
--- a/pages/sensors/[id].tsx
+++ b/pages/sensors/[id].tsx
@@ -5,7 +5,6 @@ import { LineChart } from "@components/LineChart";
 import { TextLink } from "@components/TextLink";
 import { createDateValueArray } from "@lib/dateUtil";
 import { ParsedSensorType } from "@lib/hooks/usePublicSensors";
-import { useSensorLastRecordDate } from "@lib/hooks/useSensorLastRecordDate";
 import { useSensorRecords } from "@lib/hooks/useSensorRecords";
 import { useSensorRecordsCount } from "@lib/hooks/useSensorRecordsCount";
 import { GetRecordsOptionsType } from "@lib/requests/getRecordsBySensorId";
@@ -13,7 +12,7 @@ import { getSensorData } from "@lib/requests/getSensorData";
 import DownloadIcon from "../../public/images/icons/16px/arrowDownWithHalfSquare.svg";
 import moment from "moment";
 import { GetServerSideProps } from "next";
-import React, { FC, useCallback, useEffect, useState } from "react";
+import React, { FC, useCallback, useState } from "react";
 import { SensorPageHeaderWithData } from "@components/SensorPageHeader/withData";
 import { useDownloadQueue } from "@lib/hooks/useDownloadQueue";
 import { downloadCSVString } from "@lib/downloadCsvUtil";
@@ -55,10 +54,9 @@ const SensorPage: FC<{
     startDateTimeString: string | undefined;
     endDateTimeString: string | undefined;
   }>({
-    startDateTimeString: tenDaysAgo.toISOString(),
-    endDateTimeString: today.toISOString(),
+    startDateTimeString: undefined,
+    endDateTimeString: undefined,
   });
-  const { lastRecordDate } = useSensorLastRecordDate(sensor.id);
   const { count: recordsCount } = useSensorRecordsCount(sensor.id);
   const {
     records,
@@ -72,17 +70,6 @@ const SensorPage: FC<{
     maxRows: MAX_RENDERABLE_VALUES_LINE_CHART,
   });
   const parsedAndSortedRecords = createDateValueArray(records);
-
-  useEffect(() => {
-    if (!lastRecordDate) return;
-    setCurrentDatetimeRange({
-      startDateTimeString: moment
-        .parseZone(lastRecordDate)
-        .subtract(7, "days")
-        .toISOString(),
-      endDateTimeString: moment.parseZone(lastRecordDate).toISOString(),
-    });
-  }, [lastRecordDate, setCurrentDatetimeRange]);
 
   const chartWrapper = useCallback((node: HTMLDivElement | null) => {
     if (!node) return;

--- a/src/components/DeviceLineChartFilters/DeviceLineChartFilters.test.tsx
+++ b/src/components/DeviceLineChartFilters/DeviceLineChartFilters.test.tsx
@@ -34,6 +34,8 @@ describe("DeviceLineChartFilters", () => {
     radio1.focus();
     expect(radio1).toHaveFocus();
 
+    radio1.click();
+
     userEvent.tab();
     expect(date1).toHaveFocus();
 

--- a/src/components/DeviceLineChartFilters/__snapshots__/DeviceLineChartFilters.stories.storyshot
+++ b/src/components/DeviceLineChartFilters/__snapshots__/DeviceLineChartFilters.stories.storyshot
@@ -12,17 +12,20 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
       onClick={[Function]}
     >
       <div
+        className="absolute w-full h-full inset-0 left-7 z-30 bg-white opacity-50 pointer-events-none"
+      />
+      <div
         className="flex gap-1"
       >
         <input
-          checked={true}
+          checked={false}
           name="devicesByDatetimeRange"
           readOnly={true}
           tabIndex={0}
           type="radio"
         />
         <label
-          className="inline-block text-sm mb-2 text-blue"
+          className="inline-block text-sm mb-2 "
           htmlFor="devicesByDatetimeRange"
         >
           Messwerte nach Zeitspanne
@@ -46,7 +49,7 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 placeholder="DD/MM/YYYY"
-                tabIndex={0}
+                tabIndex={-1}
                 value="11/08/2021"
               />
             </div>
@@ -54,7 +57,7 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
               className="InputTime-from font-mono relative focus:z-30 w-[4.5rem] text-center inline-block border border-gray-200 p-1.5 "
               onChange={[Function]}
               style={Object {}}
-              tabIndex={0}
+              tabIndex={-1}
               type="text"
               value="13:13"
             />
@@ -71,7 +74,7 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 placeholder="DD/MM/YYYY"
-                tabIndex={0}
+                tabIndex={-1}
                 value="01/08/2021"
               />
             </div>
@@ -79,7 +82,7 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
               className="InputTime-to font-mono relative focus:z-30 w-[4.5rem] text-center inline-block border border-gray-200 p-1.5 "
               onChange={[Function]}
               style={Object {}}
-              tabIndex={0}
+              tabIndex={-1}
               type="text"
               value="19:19"
             />
@@ -92,20 +95,17 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
       onClick={[Function]}
     >
       <div
-        className="absolute w-full h-full inset-0 left-7 z-30 bg-white opacity-50 pointer-events-none"
-      />
-      <div
         className="flex gap-1"
       >
         <input
-          checked={false}
+          checked={true}
           name="devicesByTimespan"
           readOnly={true}
           tabIndex={0}
           type="radio"
         />
         <label
-          className="inline-block text-sm mb-2 "
+          className="inline-block text-sm mb-2 text-blue"
           htmlFor="devicesByTimespan"
         >
           Messwerte nach Zeitraum
@@ -136,7 +136,7 @@ exports[`Storyshots Forms/DeviceLineChartFilters Default 1`] = `
             30 Tage
           </button>
           <button
-            className="border border-gray-200 px-2 sm:px-3 py-2 text-sm relative transition focus:outline-none focus:ring-2 focus:border-purple focus:ring-purple focus:z-30 focus:ring-offset focus:ring-offset-white focus:ring-offset-2 hover:bg-purple hover:bg-opacity-10 hover:text-purple hover:border-purple hover:z-10 ml-[-1px]"
+            className="border border-gray-200 px-2 sm:px-3 py-2 text-sm relative transition focus:outline-none focus:ring-2 focus:border-purple focus:ring-purple focus:z-30 focus:ring-offset focus:ring-offset-white focus:ring-offset-2 ml-[-1px] bg-blue border-blue text-white z-20"
             onClick={[Function]}
           >
             Alle

--- a/src/components/DeviceLineChartFilters/index.tsx
+++ b/src/components/DeviceLineChartFilters/index.tsx
@@ -101,7 +101,7 @@ export const DeviceLineChartFilters: FC<DeviceLineChartFiltersPropType> = ({
   const [activeFilterType, setActiveFilterType] =
     useState<FilterType>("devicesByTimespan");
   const [temporalityOfRecords, setTemporaityOfRecords] =
-    useState<TimespanType>("all");
+    useState<TimespanType>("max");
   const last7daysTimeRange = getTimeRangeByTimespan("last7days", today);
   return (
     <div className='pb-4 pt-8 flex flex-wrap gap-8'>

--- a/src/components/DeviceLineChartFilters/index.tsx
+++ b/src/components/DeviceLineChartFilters/index.tsx
@@ -98,11 +98,10 @@ export const DeviceLineChartFilters: FC<DeviceLineChartFiltersPropType> = ({
   onDatetimeRangeChange,
   today = moment.parseZone(Date.now()),
 }) => {
-  const [activeFilterType, setActiveFilterType] = useState<FilterType>(
-    "devicesByDatetimeRange"
-  );
+  const [activeFilterType, setActiveFilterType] =
+    useState<FilterType>("devicesByTimespan");
   const [temporalityOfRecords, setTemporaityOfRecords] =
-    useState<TimespanType>("last24h");
+    useState<TimespanType>("all");
   const last7daysTimeRange = getTimeRangeByTimespan("last7days", today);
   return (
     <div className='pb-4 pt-8 flex flex-wrap gap-8'>


### PR DESCRIPTION
This PR sets the default time filter of the line chart on the sensor page as "All", because we know have better labels and a better indication for too data-intensive charts.