### PR TITLE
fix(STADTPULS-521): fix Firefox glitch of disappearing grid

### DIFF
--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -62,12 +62,12 @@ const AccountsOverview: FC<AccountsOverviewPropType> = ({
 
   if ((!accounts || accounts.length === 0) && pageIsWithinPageCount)
     return (
-      <div className='container mx-auto max-w-8xl py-24 px-4'>
+      <div className='container mx-auto max-w-8xl pt-12 pb-24 px-4'>
         <h1 className='flex justify-center mt-8'>Keine Accounts vorhanden</h1>
       </div>
     );
   return (
-    <div className='container mx-auto max-w-8xl py-24 px-4'>
+    <div className='container mx-auto max-w-8xl pt-12 pb-24 px-4'>
       <div
         className={classNames(
           "sm:mt-1 md:mt-2",

--- a/pages/sensors/index.tsx
+++ b/pages/sensors/index.tsx
@@ -70,7 +70,7 @@ const SensorsOverview: FC<SensorsOverviewPropType> = ({
     );
 
   return (
-    <div className='container mx-auto max-w-8xl py-24 px-4'>
+    <div className='container mx-auto max-w-8xl pt-12 pb-24 px-4'>
       <div
         className={classNames(
           "sm:mt-1 md:mt-2",

--- a/src/components/Header/__snapshots__/Header.stories.storyshot
+++ b/src/components/Header/__snapshots__/Header.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Layout/Header Default 1`] = `
 <header
-  className="w-full z-50 top-0 border-t-0 sticky float-left"
+  className="w-full z-50 top-0 border-t-0 sticky"
 >
   <nav
     className="w-full border transition border-t-0 flex place-content-between container mx-auto max-w-8xl bg-black-dot-pattern border-purple text-white"

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -29,12 +29,13 @@ export const Header: React.FC = () => {
     return () => document.removeEventListener("scroll", onScroll);
   }, [setHasScrolled]);
   const isDocs = pathname?.startsWith("/docs");
+  const isHome = pathname === "/";
 
   return (
     <header
       className={[
         "w-full z-50 top-0 border-t-0",
-        isDocs ? "fixed" : "sticky",
+        isHome ? "sticky float-left" : !isDocs ? "sticky" : "fixed",
       ].join(" ")}
     >
       <nav

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -34,7 +34,7 @@ export const Header: React.FC = () => {
     <header
       className={[
         "w-full z-50 top-0 border-t-0",
-        isDocs ? "fixed" : "sticky float-left",
+        isDocs ? "fixed" : "sticky",
       ].join(" ")}
     >
       <nav

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -29,18 +29,12 @@ export const Header: React.FC = () => {
     return () => document.removeEventListener("scroll", onScroll);
   }, [setHasScrolled]);
   const isDocs = pathname?.startsWith("/docs");
-  const isHome = pathname === "/";
-  const isSensorPage = pathname?.startsWith("/sensors/[id]");
 
   return (
     <header
       className={[
         "w-full z-50 top-0 border-t-0",
-        isHome || isSensorPage
-          ? "sticky float-left"
-          : !isDocs
-          ? "sticky"
-          : "fixed",
+        isDocs ? "fixed" : "sticky",
       ].join(" ")}
     >
       <nav

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -30,12 +30,17 @@ export const Header: React.FC = () => {
   }, [setHasScrolled]);
   const isDocs = pathname?.startsWith("/docs");
   const isHome = pathname === "/";
+  const isSensorPage = pathname?.startsWith("/sensors/[id]");
 
   return (
     <header
       className={[
         "w-full z-50 top-0 border-t-0",
-        isHome ? "sticky float-left" : !isDocs ? "sticky" : "fixed",
+        isHome || isSensorPage
+          ? "sticky float-left"
+          : !isDocs
+          ? "sticky"
+          : "fixed",
       ].join(" ")}
     >
       <nav

--- a/src/components/LandingHero/__snapshots__/LandingHero.stories.storyshot
+++ b/src/components/LandingHero/__snapshots__/LandingHero.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Promotional/LandingHero Default 1`] = `
 <section
-  className="bg-black-dot-pattern relative z-0"
+  className="bg-black-dot-pattern relative z-0 mt-[calc(-1*var(--headerHeight))]"
 >
   <div>
     <div

--- a/src/components/LandingHero/index.tsx
+++ b/src/components/LandingHero/index.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { FC } from "react";
 
 export const LandingHero: FC = () => (
-  <section className='bg-black-dot-pattern relative z-0'>
+  <section className='bg-black-dot-pattern relative z-0 mt-[calc(-1*var(--headerHeight))]'>
     <div>
       <div
         className={[

--- a/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
+++ b/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
@@ -58,7 +58,7 @@ exports[`Storyshots Layout/SensorPageHeader Maximum Props 1`] = `
     className="container max-w-8xl mx-auto relative z-10"
   >
     <aside
-      className="md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]"
+      className="md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]"
     >
       <a
         className="text-blue hover:text-purple transition items-center font-bold flex gap-2 mb-8 text-sm sm:text-base focus-offset"
@@ -726,7 +726,7 @@ exports[`Storyshots Layout/SensorPageHeader Minimum Props 1`] = `
     className="container max-w-8xl mx-auto relative z-10"
   >
     <aside
-      className="md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]"
+      className="md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]"
     >
       <a
         className="text-blue hover:text-purple transition items-center font-bold flex gap-2 mb-8 text-sm sm:text-base focus-offset"

--- a/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
+++ b/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
@@ -58,7 +58,7 @@ exports[`Storyshots Layout/SensorPageHeader Maximum Props 1`] = `
     className="container max-w-8xl mx-auto relative z-10"
   >
     <aside
-      className="md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]"
+      className="md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]"
     >
       <a
         className="text-blue hover:text-purple transition items-center font-bold flex gap-2 mb-8 text-sm sm:text-base focus-offset"
@@ -726,7 +726,7 @@ exports[`Storyshots Layout/SensorPageHeader Minimum Props 1`] = `
     className="container max-w-8xl mx-auto relative z-10"
   >
     <aside
-      className="md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]"
+      className="md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]"
     >
       <a
         className="text-blue hover:text-purple transition items-center font-bold flex gap-2 mb-8 text-sm sm:text-base focus-offset"

--- a/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
+++ b/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Layout/SensorPageHeader Maximum Props 1`] = `
 <div
-  className="bg-gray-50 relative"
+  className="bg-gray-50 relative mt-[calc(-1*var(--headerHeight))]"
 >
   <div
     className="md:absolute z-0 inset-0 bg-purple bg-opacity-5 grid md:grid-cols-2 h-80 md:h-auto"
@@ -670,7 +670,7 @@ exports[`Storyshots Layout/SensorPageHeader Maximum Props 1`] = `
 
 exports[`Storyshots Layout/SensorPageHeader Minimum Props 1`] = `
 <div
-  className="bg-gray-50 relative"
+  className="bg-gray-50 relative mt-[calc(-1*var(--headerHeight))]"
 >
   <div
     className="md:absolute z-0 inset-0 bg-purple bg-opacity-5 grid md:grid-cols-2 h-80 md:h-auto"

--- a/src/components/SensorPageHeader/index.tsx
+++ b/src/components/SensorPageHeader/index.tsx
@@ -143,7 +143,7 @@ export const SensorPageHeader: FC<SensorPageHeaderPropType> = ({
       <div
         className={["container max-w-8xl", "mx-auto relative z-10"].join(" ")}
       >
-        <aside className='md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]'>
+        <aside className='md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]'>
           <BackLink />
           <Title name={name} symbolId={symbolId} />
           <div className='flex gap-4'>

--- a/src/components/SensorPageHeader/index.tsx
+++ b/src/components/SensorPageHeader/index.tsx
@@ -143,7 +143,7 @@ export const SensorPageHeader: FC<SensorPageHeaderPropType> = ({
       <div
         className={["container max-w-8xl", "mx-auto relative z-10"].join(" ")}
       >
-        <aside className='md:w-1/2 bg-white px-4 py-8 md:py-24 md:pr-12 md:max-w-[560px]'>
+        <aside className='md:w-1/2 bg-white px-4 py-8 md:py-40 md:pr-12 md:max-w-[560px]'>
           <BackLink />
           <Title name={name} symbolId={symbolId} />
           <div className='flex gap-4'>

--- a/src/components/SensorPageHeader/index.tsx
+++ b/src/components/SensorPageHeader/index.tsx
@@ -138,7 +138,7 @@ export const SensorPageHeader: FC<SensorPageHeaderPropType> = ({
   onEditButtonClick = () => undefined,
 }) => {
   return (
-    <div className='bg-gray-50 relative'>
+    <div className='bg-gray-50 relative mt-[calc(-1*var(--headerHeight))]'>
       <MapBackground geocoordinates={{ latitude, longitude }} />
       <div
         className={["container max-w-8xl", "mx-auto relative z-10"].join(" ")}

--- a/src/components/UserInfoHeader/withData.tsx
+++ b/src/components/UserInfoHeader/withData.tsx
@@ -109,7 +109,7 @@ export const UserInfoWithData: FC<UserInfoWithDataPropType> = ({
           onDelete={() => setDeletionConfirmationIsOpened(true)}
         />
       )}
-      <div className={`border-b border-gray-200 pt-20`}>
+      <div className={`border-b border-gray-200`}>
         <div className='container max-w-8xl mx-auto px-4 relative'>
           {(error || showEditSuccessAlert) && (
             <div className={["w-full z-50"].join(" ")}>

--- a/src/components/UserInfoHeader/withData.tsx
+++ b/src/components/UserInfoHeader/withData.tsx
@@ -109,7 +109,7 @@ export const UserInfoWithData: FC<UserInfoWithDataPropType> = ({
           onDelete={() => setDeletionConfirmationIsOpened(true)}
         />
       )}
-      <div className={`border-b border-gray-200`}>
+      <div className={`border-b border-gray-200 pt-4`}>
         <div className='container max-w-8xl mx-auto px-4 relative'>
           {(error || showEditSuccessAlert) && (
             <div className={["w-full z-50"].join(" ")}>

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -113,6 +113,10 @@
       font-style: monospace;
   }
 
+  :root {
+    --headerHeight: 62px;
+  }
+
   main#home {
     max-width: 100vw;
   }


### PR DESCRIPTION
This PR removes the `float: left;` from the header of all pages except the `/docs`. While this seems to solve the display issue, I can't quite say why. It seems that using `float: left;` creates some positioning glitch (only in Firefox).

Do you have any idea why this happens @vogelino? Also, do you remember what was the reason for adding that style while building the beta banner?