### PR TITLE
Better inline code styles in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,3 @@ You can commit using the `npm run cm` command to ensure your commits follow our 
 ## Deployment
 
 The frontend is currently deployed to [Vercel](https://vercel.com/). Pushing to the `main` branch will automatically trigger a new deploy (this should be avoided, if possible).
-

--- a/src/components/DocsSidebar/__snapshots__/DocsSidebar.stories.storyshot
+++ b/src/components/DocsSidebar/__snapshots__/DocsSidebar.stories.storyshot
@@ -25,7 +25,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -37,7 +37,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/about"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -49,7 +49,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/faq"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -61,7 +61,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/terms"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -82,7 +82,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/stadtpuls-account"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -94,7 +94,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/new-sensor"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -106,7 +106,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/new-device"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -118,7 +118,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/ttn-configuration"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -130,7 +130,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/view-device-data"
               onClick={[Function]}
               onMouseEnter={[Function]}
@@ -142,7 +142,7 @@ exports[`Storyshots Navigation/DocsSidebar Default 1`] = `
             className="mb-3"
           >
             <a
-              className="navigation-link p-4 block sm:inline"
+              className="navigation-link block sm:inline"
               href="/docs/troubleshooting"
               onClick={[Function]}
               onMouseEnter={[Function]}

--- a/src/components/DocsSidebar/index.tsx
+++ b/src/components/DocsSidebar/index.tsx
@@ -66,7 +66,7 @@ const PagesGroup: FC<PagesGroupPropType> = ({ title, pages }) => (
       {pages.map(page => (
         <li key={page.path} className='mb-3'>
           <ActiveLink activeClassName='navigation-link-active' href={page.path}>
-            <a href={page.path} className='navigation-link p-4 block sm:inline'>
+            <a href={page.path} className='navigation-link block sm:inline'>
               {page.title}
             </a>
           </ActiveLink>

--- a/src/components/layouts/docs.tsx
+++ b/src/components/layouts/docs.tsx
@@ -41,13 +41,14 @@ const DocsLayout: MDXLayoutType = ({ children, frontMatter }) => {
             <meta name='description' content={frontMatter.metaDescription} />
           </Head>
           <div className='md:bg-white-dot-pattern'>
-            <div
-              className={[
-                "relative z-0 md:bg-gradient-to-l from-white",
-                "px-4 pb-0 py-6 sm:px-8 sm:pt-12 md:p-12 md:pt-18 lg:p-18 lg:pt-24",
-              ].join(" ")}
-            >
-              <div className='container mx-auto' style={{ maxWidth: "89ch" }}>
+            <div className='relative z-0 md:bg-gradient-to-l from-white'>
+              <div
+                className={[
+                  "text-base",
+                  "container max-w-none",
+                  "px-4 pb-0 py-6 sm:p-8 sm:pt-12 md:pt-18 md:px-12 lg:px-18 lg:pt-24",
+                ].join(" ")}
+              >
                 <h1
                   id='main-headline'
                   className={[
@@ -63,7 +64,7 @@ const DocsLayout: MDXLayoutType = ({ children, frontMatter }) => {
           <div
             className={[
               "relative z-0",
-              "container mx-auto prose lg:prose-lg 2xl:prose-2xl prose-purple",
+              "container prose prose-purple",
               "px-4 py-6 sm:p-8 sm:pb-12 md:p-12 md:pb-18 lg:p-18 lg:pb-24",
             ].join(" ")}
           >

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -203,6 +203,21 @@
     @apply font-headline;
   }
 
+  main .prose code {
+    display: inline-block;
+    @apply bg-gray-100 font-mono;
+    font-size: 1.05em;
+    padding: 0 .4rem;
+    margin: 0 .1rem;
+    font-weight: 500;
+  }
+
+  .prose code::after,
+  .prose code::before {
+    content: "";
+    display: none;
+  }
+
   main#docs .prose a {
     @apply text-blue underline-green hover:text-purple transition font-headline font-bold;
   }


### PR DESCRIPTION
This PR fixes the styles of the inline code elements in the docs.

**Before:**
<img width="218" alt="Screen Shot 2021-11-24 at 4 52 32 PM" src="https://user-images.githubusercontent.com/2759340/143271280-39e2a25d-6ae7-4565-962d-960d5c5e84b8.png">

**After:**
<img width="334" alt="Screen Shot 2021-11-24 at 4 51 40 PM" src="https://user-images.githubusercontent.com/2759340/143271133-d90802b2-a28a-44c6-b0a6-db8a76c9a6e9.png">
