### PR TITLE
fix(STADTPULS-520): Remove spinner from loading bar

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,7 +34,11 @@ const App: FC<{
       <AuthProvider>
         <DownloadQueueProvider>
           <Head />
-          <NextNProgress stopDelayMs={50} color={colors.green} />
+          <NextNProgress
+            stopDelayMs={50}
+            color={colors.green}
+            options={{ showSpinner: false }}
+          />
           {!pathname?.startsWith("/docs") && <BetaBanner />}
           <main
             id={pathname?.replace(/\//gi, "") || "home"}


### PR DESCRIPTION
This PR removes the Loading spinner from the loading bar in the top as it always overlaps with other elements and there is no easy quick way to move it somewhere else. The progress bar should be enough to indicate progress.