### PR TITLE
chore(STADTPULS-468): truncate cards at 100 chars for description

### DIFF
--- a/src/components/AccountCard/AccountCard.test.tsx
+++ b/src/components/AccountCard/AccountCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { AccountCard } from ".";
+import { AccountCard, DESCRIPTION_MAX_LENGTH } from ".";
 
 const testProps = {
   displayName: "Louis Dieudonné de Bourbon",
@@ -19,7 +19,7 @@ describe("AccountCard component", () => {
     const name = screen.getByRole("heading", { name: testProps.displayName });
     const username = screen.getByText(`@${testProps.username}`);
     const description = screen.getByText(
-      `${testProps.description.slice(0, 50)}...`
+      `${testProps.description.slice(0, DESCRIPTION_MAX_LENGTH)}...`
     );
     const sensorsCount = screen.queryByText("12.345");
     const recordsCount = screen.queryByText("12 Mio.");

--- a/src/components/AccountCard/__snapshots__/AccountCard.stories.storyshot
+++ b/src/components/AccountCard/__snapshots__/AccountCard.stories.storyshot
@@ -502,7 +502,7 @@ exports[`Storyshots UI Elements/AccountCard Default 1`] = `
       <p
         className="pt-2"
       >
-        Louis XIV, also known as Louis the Great or the Su...
+        Louis XIV, also known as Louis the Great or the Sun King, was King of France from 14 May 1643 until ...
       </p>
       <div
         className="flex gap-4 sm:gap-6 md:gap-8 justify-self-end items-center pt-6"
@@ -1640,7 +1640,7 @@ exports[`Storyshots UI Elements/AccountCard Too Many Categories 1`] = `
       <p
         className="pt-2"
       >
-        Louis XIV, also known as Louis the Great or the Su...
+        Louis XIV, also known as Louis the Great or the Sun King, was King of France from 14 May 1643 until ...
       </p>
       <div
         className="flex gap-4 sm:gap-6 md:gap-8 justify-self-end items-center pt-6"

--- a/src/components/AccountCard/index.tsx
+++ b/src/components/AccountCard/index.tsx
@@ -13,7 +13,7 @@ export interface AccountCardPropType {
   categories?: number[];
 }
 
-const DESCRIPTION_MAX_LENGTH = 50;
+export const DESCRIPTION_MAX_LENGTH = 100;
 
 const numberFormatter = new Intl.NumberFormat("de-DE", {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
+++ b/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
@@ -1173,7 +1173,7 @@ exports[`Storyshots Promotional/LandingSensorsSlider Default 1`] = `
                 <p
                   className="text-base"
                 >
-                  Through perseverance many people win success out of what seemed destined to be certain failure. - Benjamin Disraeli
+                  Through perseverance many people win success out of what seemed destined to be certain failure. - Be...
                 </p>
                 <p
                   className="mt-4 mb-2 flex gap-2 flex-wrap"

--- a/src/components/SensorCard/SensorCard.test.tsx
+++ b/src/components/SensorCard/SensorCard.test.tsx
@@ -1,7 +1,7 @@
 import { mapPublicSensor } from "@lib/hooks/usePublicSensors";
 import { sensors } from "@mocks/supabaseData/sensors";
 import { render, screen } from "@testing-library/react";
-import { SensorCard } from ".";
+import { DESCRIPTION_MAX_LENGTH, SensorCard } from ".";
 
 jest.mock("use-is-in-viewport", () => jest.fn().mockReturnValue([true, null]));
 
@@ -29,7 +29,7 @@ describe("SensorCard", () => {
     expect(author).toBeInTheDocument();
   });
   it("should trim too long descriptions", () => {
-    const tooLongDescription = Array.from(Array(300))
+    const tooLongDescription = Array.from(Array(500))
       .map(() => "A")
       .join("");
     render(
@@ -39,7 +39,9 @@ describe("SensorCard", () => {
       />
     );
 
-    const desc = screen.getByText(`${tooLongDescription.slice(0, 150)}...`);
+    const desc = screen.getByText(
+      `${tooLongDescription.slice(0, DESCRIPTION_MAX_LENGTH)}...`
+    );
     expect(desc).toBeInTheDocument();
   });
 });

--- a/src/components/SensorCard/__snapshots__/SensorCard.stories.storyshot
+++ b/src/components/SensorCard/__snapshots__/SensorCard.stories.storyshot
@@ -59,7 +59,7 @@ exports[`Storyshots UI Elements/SensorCard Long Fields 1`] = `
         <p
           className="text-base"
         >
-          @wdanxna when Array is given multiple arguments, it iterates over the arguments object and explicitly applies each value to the new array. When you ca...
+          @wdanxna when Array is given multiple arguments, it iterates over the arguments object and explicitl...
         </p>
         <p
           className="mt-4 mb-2 flex gap-2 flex-wrap"

--- a/src/components/SensorCard/index.tsx
+++ b/src/components/SensorCard/index.tsx
@@ -14,7 +14,7 @@ export interface SensorCardPropType extends ParsedSensorType {
 }
 
 const DISPLAYABLE_RECORDS_AMOUNT = 20;
-const DESCRIPTION_MAX_LENGTH = 150;
+export const DESCRIPTION_MAX_LENGTH = 100;
 
 export const SensorCard: FC<SensorCardPropType> = ({
   id,

--- a/src/components/SensorsGrid/__snapshots__/SensorsGrid.stories.storyshot
+++ b/src/components/SensorsGrid/__snapshots__/SensorsGrid.stories.storyshot
@@ -1149,7 +1149,7 @@ exports[`Storyshots Pages/SensorsGrid Default 1`] = `
         <p
           className="text-base"
         >
-          Through perseverance many people win success out of what seemed destined to be certain failure. - Benjamin Disraeli
+          Through perseverance many people win success out of what seemed destined to be certain failure. - Be...
         </p>
         <p
           className="mt-4 mb-2 flex gap-2 flex-wrap"


### PR DESCRIPTION
This was missed in the first PR for STADTPULS-468.