### PR TITLE
fix(STADTPULS-476): don't revalidate records on focus

### DIFF
--- a/src/lib/hooks/useSensorRecords/index.ts
+++ b/src/lib/hooks/useSensorRecords/index.ts
@@ -53,13 +53,18 @@ export const useSensorRecords = ({
     endDateString,
     maxRows,
   ];
-  const { data, error } = useSWR<GetRecordsResponseType, Error>(params, () =>
-    fetchSensorRecords({
-      sensorId,
-      startDateString,
-      endDateString,
-      maxRows,
-    })
+  const { data, error } = useSWR<GetRecordsResponseType, Error>(
+    params,
+    () =>
+      fetchSensorRecords({
+        sensorId,
+        startDateString,
+        endDateString,
+        maxRows,
+      }),
+    {
+      revalidateOnFocus: false,
+    }
   );
 
   return {


### PR DESCRIPTION
This PR is a fix for STADTPULS-476. For now, we want to keep the records from refreshing when re-focussing, so this option is deactivated in SWR.

In order to observe the change, follow these steps:

1. Open the page of one of your sensors and scroll to the line chart
2. Add a record to the sensor. If using SQL, you can use `INSERT INTO records (recorded_at, measurements, sensor_id) VALUES (now(), '{42}', <YOUR_SENSOR_ID>);`
3. When re-focussing the sensor page tab, the line chart and the filters should _not_ be updated. This will only happen when updating the filters or refreshing the page.

---

Closes #178 that has an outdated fix.