### PR TITLE
hotfix(postgrest query): Adds hint for postgrest

### DIFF
--- a/src/lib/requests/getPublicSensors/index.ts
+++ b/src/lib/requests/getPublicSensors/index.ts
@@ -29,7 +29,7 @@ export const sensorQueryString = `
     recorded_at,
     measurements
   ),
-  user:user_id (
+  user:user_profiles!user_id (
     name,
     display_name
   ),


### PR DESCRIPTION
postgrest seems to lookup all foreign keys. Since there is a fk user_id on the new extended view and the user_profiles
it gets confused https://postgrest.org/en/v9.0/api.html#hint-disambiguation