### PR TITLE
fix(STADTPULS-564): geolocation in sensor modal

### DIFF
--- a/src/components/EditAddSensorModal/index.tsx
+++ b/src/components/EditAddSensorModal/index.tsx
@@ -101,13 +101,10 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
     viewport.latitude !== defaultValues?.latitude ||
     viewport.longitude !== defaultValues?.longitude;
 
-  const [latitude, setLatitude] = useState(viewport.latitude || DEFAULT_LAT);
-  const [longitude, setLongitude] = useState(viewport.longitude || DEFAULT_LNG);
-
   useEffect(() => {
-    setValue("latitude", latitude);
-    setValue("longitude", longitude);
-  }, [latitude, longitude, setValue]);
+    viewport.latitude && setValue("latitude", viewport.latitude);
+    viewport.longitude && setValue("longitude", viewport.longitude);
+  }, [viewport.latitude, viewport.longitude, setValue]);
 
   const {
     categories,
@@ -382,8 +379,6 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
               withMapLabels
               className='pointer-events-none'
               onViewportChange={viewport => {
-                setLatitude(viewport.latitude);
-                setLongitude(viewport.longitude);
                 setViewport(viewport);
               }}
             />

--- a/src/components/EditAddSensorModal/index.tsx
+++ b/src/components/EditAddSensorModal/index.tsx
@@ -100,6 +100,15 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
     Object.values(dirtyFields).length > 0 ||
     viewport.latitude !== defaultValues?.latitude ||
     viewport.longitude !== defaultValues?.longitude;
+
+  const [latitude, setLatitude] = useState(viewport.latitude || DEFAULT_LAT);
+  const [longitude, setLongitude] = useState(viewport.longitude || DEFAULT_LNG);
+
+  useEffect(() => {
+    setValue("latitude", latitude);
+    setValue("longitude", longitude);
+  }, [latitude, longitude, setValue]);
+
   const {
     categories,
     isLoading: isLoadingCategories,
@@ -373,16 +382,16 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
               withMapLabels
               className='pointer-events-none'
               onViewportChange={viewport => {
+                setLatitude(viewport.latitude);
+                setLongitude(viewport.longitude);
                 setViewport(viewport);
-                setValue("latitude", viewport.latitude);
-                setValue("longitude", viewport.longitude);
               }}
             />
             <span className='w-3 h-3 rounded-full bg-blue absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2' />
           </fieldset>
           <p className='text-sm text-gray-500 mt-2 grid grid-cols-[16px,1fr] gap-2 items-center'>
             <GrabbingHandIcon />
-            Bewege die Karte, sodass der Punkt auf dein Standort liegt.
+            Bewege die Karte so, dass der Punkt auf deinen Sensor zeigt.
           </p>
         </div>
         <div className='flex w-full sm:justify-between flex-wrap gap-4 items-end'>

--- a/src/components/EditAddSensorModal/index.tsx
+++ b/src/components/EditAddSensorModal/index.tsx
@@ -94,7 +94,7 @@ export const EditAddSensorModal: FC<EditAddSensorModalPropType> = ({
   const [viewport, setViewport] = useState<Partial<InteractiveMapProps>>({
     latitude: defaultValues?.latitude || DEFAULT_LAT,
     longitude: defaultValues?.longitude || DEFAULT_LNG,
-    zoom: 12,
+    zoom: 16,
   });
   const isDirty =
     Object.values(dirtyFields).length > 0 ||

--- a/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
+++ b/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Promotional/LandingSensorsSlider Default 1`] = `
 <section
-  className="overflow-hidden px-8 md:px-24 lg:px-32 xl:px-40 -mt-4 md:-mt-8 lg:-mt-12 z-20 relative"
+  className="overflow-hidden px-8 md:px-24 lg:px-32 xl:px-40 -translate-y-4 z-20 relative"
 >
   <div>
     <div

--- a/src/components/LandingSensorsSlider/index.tsx
+++ b/src/components/LandingSensorsSlider/index.tsx
@@ -55,7 +55,7 @@ export const LandingSensorsSlider: FC<LandingSensorsSliderPropType> = ({
     <section
       className={[
         "overflow-hidden px-8 md:px-24 lg:px-32 xl:px-40",
-        "-mt-4 md:-mt-8 lg:-mt-12 z-20 relative",
+        "-translate-y-4 z-20 relative",
       ].join(" ")}
     >
       <div className={styles.sliderParent}>

--- a/src/components/LandingStoriesIntro/__snapshots__/LandingStoriesIntro.stories.storyshot
+++ b/src/components/LandingStoriesIntro/__snapshots__/LandingStoriesIntro.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`Storyshots Promotional/LandingStoriesIntro Default 1`] = `
 <section
-  className="relative z-10 w-full pt-64 lg:pt-56 px-4 bg-white-dot-pattern"
+  className="relative z-10 w-full pt-64 px-4 bg-white-dot-pattern"
 >
   <div
-    className="bg-white border border-gray-200 shadow grid grid-cols-1 md:grid-cols-8 mx-auto max-w-screen-lg translate-y-4 md:translate-y-8 lg:translate-y-12"
+    className="bg-white border border-gray-200 shadow grid grid-cols-1 md:grid-cols-8 mx-auto max-w-screen-lg translate-y-4"
   >
     <div
       className="col-span-3 relative -order-1 md:order-1"

--- a/src/components/LandingStoriesIntro/index.tsx
+++ b/src/components/LandingStoriesIntro/index.tsx
@@ -7,7 +7,7 @@ export const LandingStoriesIntro: FC = () => (
     className={[
       "relative z-10",
       "w-full",
-      "pt-64 lg:pt-56",
+      "pt-64",
       "px-4",
       "bg-white-dot-pattern",
     ].join(" ")}
@@ -18,7 +18,7 @@ export const LandingStoriesIntro: FC = () => (
         "border border-gray-200 shadow",
         "grid grid-cols-1 md:grid-cols-8",
         "mx-auto max-w-screen-lg",
-        "translate-y-4 md:translate-y-8 lg:translate-y-12",
+        "translate-y-4",
       ].join(" ")}
     >
       <div className={`col-span-3 relative -order-1 md:order-1`}>

--- a/src/components/SensorPageHeader/index.tsx
+++ b/src/components/SensorPageHeader/index.tsx
@@ -27,7 +27,11 @@ const MapBackground: FC<{
   >
     <div className='bg-white hidden md:block' />
     <div className='relative'>
-      <PreviewMap mapWidth='100%' mapHeight='100%' viewport={geocoordinates} />
+      <PreviewMap
+        mapWidth='100%'
+        mapHeight='100%'
+        viewport={{ ...geocoordinates, zoom: 16 }}
+      />
       <span
         className={[
           "bg-blue w-3 h-3 rounded-full absolute inline-block",


### PR DESCRIPTION
This PR fixes the following issue:

When editing a sensor by dragging the map in the `EditAddSensorModal`, the updated coordinates were sometimes lagging behind the actual map viewport. To reproduce in production, you can try moving the map _slowly_ to position your sensor somewhere else. While doing this, it can occur that the viewport change is not updated in the fields that are submitted to the DB. This way the sensor location either remains the old one, or is pretty random on the map based on where the last viewport change was submitted to the fields.

**The fix**
`latitude` and `longitude` now have their own state and whenever one of them is (correctly) updated by `onViewportChange`, `setValue` is called to update the form fields. The value is now always correctly submitted.