### PR TITLE
fix(STADTPULS-613): Make images staging-compatible

### DIFF
--- a/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
+++ b/src/components/LandingSensorsSlider/__snapshots__/LandingSensorsSlider.stories.storyshot
@@ -32,7 +32,7 @@ exports[`Storyshots Promotional/LandingSensorsSlider Default 1`] = `
               <img
                 alt="Location of sensor \\"Poison Thing\\""
                 className="w-full h-full object-cover"
-                src="/images/sensors/4.jpeg"
+                src="/images/sensors/undefined.jpeg"
               />
               <div
                 className="absolute right-0 bottom-0 left-0 h-1/2 pointer-events-none bg-gradient-to-t from-white z-30"
@@ -617,7 +617,7 @@ exports[`Storyshots Promotional/LandingSensorsSlider Default 1`] = `
               <img
                 alt="Location of sensor \\"Delicate Collapse\\""
                 className="w-full h-full object-cover"
-                src="/images/sensors/5.jpeg"
+                src="/images/sensors/undefined.jpeg"
               />
               <div
                 className="absolute right-0 bottom-0 left-0 h-1/2 pointer-events-none bg-gradient-to-t from-white z-30"
@@ -1202,7 +1202,7 @@ exports[`Storyshots Promotional/LandingSensorsSlider Default 1`] = `
               <img
                 alt="Location of sensor \\"Simple Broadcast\\""
                 className="w-full h-full object-cover"
-                src="/images/sensors/6.jpeg"
+                src="/images/sensors/undefined.jpeg"
               />
               <div
                 className="absolute right-0 bottom-0 left-0 h-1/2 pointer-events-none bg-gradient-to-t from-white z-30"

--- a/src/components/LandingSensorsSlider/index.tsx
+++ b/src/components/LandingSensorsSlider/index.tsx
@@ -7,6 +7,7 @@ import "swiper/swiper-bundle.css";
 import { ParsedSensorType } from "@lib/hooks/usePublicSensors";
 import { ArrowBack, ArrowForward } from "@material-ui/icons";
 import { SensorCard } from "@components/SensorCard";
+import { getCuratedSensorImageById } from "@lib/hooks/useCuratedSensors";
 
 interface LandingSensorsSliderPropType {
   sensors: ParsedSensorType[];
@@ -72,7 +73,7 @@ export const LandingSensorsSlider: FC<LandingSensorsSliderPropType> = ({
                   parsedRecords={sensor.parsedRecords}
                   withMapLabels={false}
                   withMapBackground={false}
-                  backgroundImage={`/images/sensors/${sensor.id}.jpeg`}
+                  backgroundImage={getCuratedSensorImageById(sensor.id)}
                 />
               </div>
             ))}

--- a/src/lib/hooks/useCuratedSensors/index.ts
+++ b/src/lib/hooks/useCuratedSensors/index.ts
@@ -10,6 +10,21 @@ import {
   RECORDS_LIMIT,
 } from "@lib/requests/getPublicSensors";
 
+// The following is a quickfix because we currently know what our curated sensors are
+// In the future we might wanna save them in a DB table
+// TODO: Refactor this!
+const isProduction =
+  process.env["NODE_ENV"] === "production" &&
+  process.env["VERCEL_ENV"] !== "preview";
+const PRODUCTION_SENSORS_IDS = [22, 23, 24, 25, 27, 28, 29];
+const STAGING_SENSORS_IDS = [41, 37, 24, 35, 38, 36, 44];
+
+export const getCuratedSensorImageById = (id: number): string => {
+  if (isProduction) return `/images/sensors/${id}.jpeg`;
+  const indexOfId = STAGING_SENSORS_IDS.indexOf(id);
+  return `/images/sensors/${PRODUCTION_SENSORS_IDS[indexOfId]}.jpeg`;
+};
+
 export const getCuratedSensors = async (): Promise<ParsedSensorType[]> => {
   const { data, error } = await supabase
     .from<SensorQueryResponseType>("sensors")
@@ -19,10 +34,7 @@ export const getCuratedSensors = async (): Promise<ParsedSensorType[]> => {
       // The following is a quickfix because we currently know what our curated sensors are
       // In the future we might wanna save them in a DB table
       // TODO: Refactor this!
-      process.env["NODE_ENV"] === "production" &&
-        process.env["VERCEL_ENV"] !== "preview"
-        ? [22, 23, 24, 25, 26, 27, 28, 29] // -> Production
-        : [35, 36, 37, 38, 39, 40, 41, 44] // -> Staging
+      isProduction ? PRODUCTION_SENSORS_IDS : STAGING_SENSORS_IDS
     )
     //FIXME: the ignorance
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Makes image on home-slider staging compatible, meaning the ids of the fake sensors on staging can also be hard-coded in order to make the previews work.
