### PR TITLE
fix(STADTPULS-608): Make logo stop spinning at some point

### DIFF
--- a/src/components/StadtpulsLogo/StadtpulsLogo.module.css
+++ b/src/components/StadtpulsLogo/StadtpulsLogo.module.css
@@ -6,7 +6,7 @@
 }
 
 .logoContainer:hover .logoImage {
-  animation: logo-hover 1s linear infinite;
+  animation: logo-hover 1s ease-in-out;
 }
 
 @keyframes logo-hover {


### PR DESCRIPTION
This PR makes the logo animate only once so it can never endlessly spin when stuck on hover on mobile devices