### PR TITLE
fix(STADTPULS-526): Fix safari ovelapping elements in story block

### DIFF
--- a/src/components/LandingStoriesIntro/__snapshots__/LandingStoriesIntro.stories.storyshot
+++ b/src/components/LandingStoriesIntro/__snapshots__/LandingStoriesIntro.stories.storyshot
@@ -15,7 +15,7 @@ exports[`Storyshots Promotional/LandingStoriesIntro Default 1`] = `
       >
         <img
           alt="Eine herbstliche Straße im Berliner Wrangelkiez"
-          className="object-cover w-full h-full"
+          className="object-cover w-full max-h-56 md:min-h-full md:max-h-full"
           src="/images/photos/wrangelkiez_street.jpg"
         />
       </div>

--- a/src/components/LandingStoriesIntro/index.tsx
+++ b/src/components/LandingStoriesIntro/index.tsx
@@ -28,7 +28,7 @@ export const LandingStoriesIntro: FC = () => (
           <img
             src='/images/photos/wrangelkiez_street.jpg'
             alt='Eine herbstliche Straße im Berliner Wrangelkiez'
-            className={`object-cover w-full h-full`}
+            className={`object-cover w-full max-h-56 md:min-h-full md:max-h-full`}
           />
         </div>
       </div>


### PR DESCRIPTION
Fix safari overlapping elements in story block

![Screen Shot 2021-12-09 at 1 27 50 PM](https://user-images.githubusercontent.com/2759340/145398405-25efc36b-31a7-4a7d-95f7-d60900a12d62.png)

