### PR TITLE
STADTPULS-643 : Create action that warns when a branch that isn't staging is Pull Requested against main

### DIFF
--- a/.github/workflows/warnForPRIntoMain.yml
+++ b/.github/workflows/warnForPRIntoMain.yml
@@ -1,3 +1,4 @@
+name: 'Prevent merge from non-staging to main'
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/warnForPRIntoMain.yml
+++ b/.github/workflows/warnForPRIntoMain.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  warn_main_merge:
+    runs-on: 'ubuntu-latest'
+    name: 'Validate PR Source and Target Branches'
+    steps:
+      - name: 'Checking source and target branch in PR'
+        uses: 'technologiestiftung/warn-for-main-merge-action@v1.13'
+        with:
+          stagingName: 'staging'
+          mainName: 'main'


### PR DESCRIPTION
This PR uses a GitHub action created in another repo, that makes sure that PRs that have another branch than staging as a source and main as a target cannot be merged (unless the checks are ignored). The repo is here:

https://github.com/technologiestiftung/warn-for-main-merge-action

~The action will not run on this PR, as it must first be merged into main in order to work.~