### PR TITLE
fix(Next.js-config): Add mapbox tiles URL to content security policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,7 +30,7 @@ module.exports = withImages(withMdxEnhanced({
               `frame-ancestors 'none'`,
               `worker-src 'self' blob:`,
               `child-src 'self' blob:`,
-              `connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL} ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_MATOMO_URL} https://api.github.com https://api.mapbox.com https://events.mapbox.com`,
+              `connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL} ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_MATOMO_URL} https://api.github.com https://api.tiles.mapbox.com https://api.mapbox.com https://events.mapbox.com`,
             ].join("; "),
           },
         ],

--- a/src/components/SensorsList/__snapshots__/SensorsList.stories.storyshot
+++ b/src/components/SensorsList/__snapshots__/SensorsList.stories.storyshot
@@ -2905,7 +2905,7 @@ exports[`Storyshots Pages/SensorsList Default 1`] = `
           <span
             className="absolute bottom-0 left-0 text-xs text-gray-300"
           >
-            Zul. vor 8 Monaten
+            Zul. vor 9 Monaten
           </span>
           <span
             className="absolute top-0 right-0 bg-white text-xs text-purple font-mono font-semibold px-0.5 py-[1px] border border-gray-200 leading-3"

--- a/src/components/SensorsMap/__snapshots__/SensorsMap.stories.storyshot
+++ b/src/components/SensorsMap/__snapshots__/SensorsMap.stories.storyshot
@@ -2930,7 +2930,7 @@ exports[`Storyshots Pages/SensorsMap Default 1`] = `
               <span
                 className="absolute bottom-0 left-0 text-xs text-gray-300"
               >
-                Zul. vor 8 Monaten
+                Zul. vor 9 Monaten
               </span>
               <span
                 className="absolute top-0 right-0 bg-white text-xs text-purple font-mono font-semibold px-0.5 py-[1px] border border-gray-200 leading-3"


### PR DESCRIPTION
This PR adds the tiles.mapbox.com URL to the content security policy rules. This URL seems to be newly used by mapbox to host tiles and wasn't formerly allows in our content security policy. This might be a problem in the future.