### PR TITLE
fix(MarkerMap): Assign different ids to markers and to clusters

### DIFF
--- a/src/components/MarkerMap/index.tsx
+++ b/src/components/MarkerMap/index.tsx
@@ -339,7 +339,7 @@ export const MarkerMap: FC<MarkerMapType> = ({
 
             return (
               <Marker
-                key={cluster.id}
+                key={`${isCluster ? "cluster" : "marker"}-${cluster.id}`}
                 latitude={latitude}
                 longitude={longitude}
               >

--- a/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
+++ b/src/components/SensorPageHeader/__snapshots__/SensorPageHeader.stories.storyshot
@@ -288,7 +288,7 @@ exports[`Storyshots Layout/SensorPageHeader Maximum Props 1`] = `
           onClick={[Function]}
           readOnly={true}
           type="text"
-          value="localhost/api/v3/sensors/1/records"
+          value="fake-token-api-url.com/api/v3/sensors/1/records"
         />
         <div
           aria-hidden={true}
@@ -604,7 +604,7 @@ exports[`Storyshots Layout/SensorPageHeader Minimum Props 1`] = `
           onClick={[Function]}
           readOnly={true}
           type="text"
-          value="localhost/api/v3/sensors/1/records"
+          value="fake-token-api-url.com/api/v3/sensors/1/records"
         />
         <div
           aria-hidden={true}

--- a/src/components/SensorPageHeaderLoadingSkeleton/__snapshots__/SensorPageHeader.stories.storyshot
+++ b/src/components/SensorPageHeaderLoadingSkeleton/__snapshots__/SensorPageHeader.stories.storyshot
@@ -383,7 +383,7 @@ Array [
             onClick={[Function]}
             readOnly={true}
             type="text"
-            value="localhost/api/v3/sensors/1/records"
+            value="fake-token-api-url.com/api/v3/sensors/1/records"
           />
           <div
             aria-hidden={true}

--- a/src/lib/requests/getRecordsBySensorId/index.ts
+++ b/src/lib/requests/getRecordsBySensorId/index.ts
@@ -1,11 +1,5 @@
 import { supabase } from "@auth/supabase";
 import { definitions } from "@technologiestiftung/stadtpuls-supabase-definitions";
-
-const MAX_DOWNLOADABLE_RECORDS = 1e6;
-const maxRows = parseInt(
-  `${process.env.NEXT_PUBLIC_SUPABASE_MAX_ROWS || "1000"}`,
-  10
-);
 export interface GetRecordsOptionsType {
   startDate?: string;
   endDate?: string;
@@ -17,114 +11,84 @@ export interface GetRecordsResponseType {
   count: number | null;
 }
 
-async function getAllRecrodsBySensorId(
-  sensorId: number,
-  prevRecords: definitions["records"][] = []
-): Promise<definitions["records"][]> {
-  const { data: records, error } = await supabase
-    .from<definitions["records"]>("records")
-    .select("*")
-    .eq("sensor_id", sensorId)
-    .order("recorded_at", { ascending: false })
-    .range(prevRecords.length, prevRecords.length + maxRows);
-
-  if (error) throw error;
-  if (!records)
-    throw new Error(
-      `No records found for sensor ID ${sensorId} at range "${
-        prevRecords.length
-      },${prevRecords.length + maxRows}"`
-    );
-
-  const aggregatedRecords = [...prevRecords, ...records];
-  if (records.length <= maxRows) return aggregatedRecords;
-  if (aggregatedRecords.length >= MAX_DOWNLOADABLE_RECORDS)
-    return aggregatedRecords;
-  return getAllRecrodsBySensorId(sensorId, aggregatedRecords);
-}
-
 export const getRecordsBySensorId = async (
   sensorId: number,
-  options?: GetRecordsOptionsType
+  options: GetRecordsOptionsType = {}
 ): Promise<GetRecordsResponseType> => {
   const MAX_ROWS =
     options?.maxRows ||
     Number.parseInt(process.env.NEXT_PUBLIC_SUPABASE_MAX_ROWS as string, 10);
 
-  if (options) {
-    switch (true) {
-      case !!(options && options.startDate && options.endDate): {
-        const {
-          data: records,
-          error,
-          count,
-        } = await supabase
-          .from<definitions["records"]>("records")
-          .select("*", { count: "exact", head: false })
-          .limit(MAX_ROWS)
-          .eq("sensor_id", sensorId)
-          .gte("recorded_at", options.startDate || "")
-          .lte("recorded_at", options.endDate || "")
-          .order("recorded_at", { ascending: false });
-        if (error) throw error;
-        if (!records) throw new Error(`No records found for this time range`);
-        return { records, count };
-      }
+  switch (true) {
+    case !!(options && options.startDate && options.endDate): {
+      const {
+        data: records,
+        error,
+        count,
+      } = await supabase
+        .from<definitions["records"]>("records")
+        .select("*", { count: "exact", head: false })
+        .limit(MAX_ROWS)
+        .eq("sensor_id", sensorId)
+        .gte("recorded_at", options.startDate || "")
+        .lte("recorded_at", options.endDate || "")
+        .order("recorded_at", { ascending: false });
+      if (error) throw error;
+      if (!records) throw new Error(`No records found for this time range`);
+      return { records, count };
+    }
 
-      case !!(options && options.startDate && !options.endDate): {
-        const {
-          data: records,
-          error,
-          count,
-        } = await supabase
-          .from<definitions["records"]>("records")
-          .select("*", { count: "exact" })
-          .limit(MAX_ROWS)
-          .eq("sensor_id", sensorId)
-          .gte("recorded_at", options.startDate || "")
-          .order("recorded_at", { ascending: false });
+    case !!(options && options.startDate && !options.endDate): {
+      const {
+        data: records,
+        error,
+        count,
+      } = await supabase
+        .from<definitions["records"]>("records")
+        .select("*", { count: "exact" })
+        .limit(MAX_ROWS)
+        .eq("sensor_id", sensorId)
+        .gte("recorded_at", options.startDate || "")
+        .order("recorded_at", { ascending: false });
 
-        if (error) throw error;
-        if (!records) throw new Error(`No records found for this time range`);
-        return { records, count };
-      }
+      if (error) throw error;
+      if (!records) throw new Error(`No records found for this time range`);
+      return { records, count };
+    }
 
-      case !!(options && !options.startDate && options.endDate): {
-        const {
-          data: records,
-          error,
-          count,
-        } = await supabase
-          .from<definitions["records"]>("records")
-          .select("*", { count: "exact" })
-          .limit(MAX_ROWS)
-          .eq("sensor_id", sensorId)
-          .lte("recorded_at", options.endDate || "")
-          .order("recorded_at", { ascending: false });
+    case !!(options && !options.startDate && options.endDate): {
+      const {
+        data: records,
+        error,
+        count,
+      } = await supabase
+        .from<definitions["records"]>("records")
+        .select("*", { count: "exact" })
+        .limit(MAX_ROWS)
+        .eq("sensor_id", sensorId)
+        .lte("recorded_at", options.endDate || "")
+        .order("recorded_at", { ascending: false });
 
-        if (error) throw error;
-        if (!records) throw new Error(`No records found for this time range`);
-        return { records, count };
-      }
+      if (error) throw error;
+      if (!records) throw new Error(`No records found for this time range`);
+      return { records, count };
+    }
 
-      default: {
-        const {
-          data: records,
-          error,
-          count,
-        } = await supabase
-          .from<definitions["records"]>("records")
-          .select("*", { count: "exact" })
-          .limit(MAX_ROWS)
-          .eq("sensor_id", sensorId)
-          .order("recorded_at", { ascending: false });
+    default: {
+      const {
+        data: records,
+        error,
+        count,
+      } = await supabase
+        .from<definitions["records"]>("records")
+        .select("*", { count: "exact" })
+        .limit(MAX_ROWS)
+        .eq("sensor_id", sensorId)
+        .order("recorded_at", { ascending: false });
 
-        if (error) throw error;
-        if (!records) throw new Error(`No records found`);
-        return { records, count };
-      }
+      if (error) throw error;
+      if (!records) throw new Error(`No records found`);
+      return { records, count };
     }
   }
-  const records = await getAllRecrodsBySensorId(sensorId);
-  return { records, count: records.length };
 };


### PR DESCRIPTION
This PR ensures that clusters and single markers never have the same IDs. This issue provoked some markers not being updated as they shared duplicated IDs.

PS: I also had to fix the function `getRecordsBySensorId` which failed in some tests when given no option (a case that was not used anywhere in business logic, so I deleted this branching and set an empty as default options) .